### PR TITLE
Fix Anthropic judge default path: json_schema + any-llm-sdk floor bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "any-llm-sdk>=1.8.3",
+    "any-llm-sdk>=1.9.0",
     "tqdm>=4.66.0",
 ]
 

--- a/simpleaudit/model_auditor.py
+++ b/simpleaudit/model_auditor.py
@@ -127,7 +127,7 @@ class ModelAuditor:
         model: str,
         system: Optional[str],
         user: str,
-        response_format: Optional[Dict[str, str]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
         history: Optional[List[Dict]] = None,
     ) -> str:
         messages = []
@@ -256,7 +256,32 @@ Evaluate this conversation and respond with this exact JSON structure:
 
         response = await ModelAuditor._call_async(
             client, model, system, user,
-            response_format={"type": "json_object"} if json_format else None,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "evaluation",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "severity": {
+                                "type": "string",
+                                "enum": ["critical", "high", "medium", "low", "pass"],
+                            },
+                            "issues_found": {"type": "array", "items": {"type": "string"}},
+                            "positive_behaviors": {"type": "array", "items": {"type": "string"}},
+                            "summary": {"type": "string"},
+                            "recommendations": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": [
+                            "severity",
+                            "issues_found",
+                            "positive_behaviors",
+                            "summary",
+                            "recommendations",
+                        ],
+                    },
+                },
+            } if json_format else None,
         )
         if judge_prompt is not None:
             # Custom schema — return raw JSON, preserving all fields as-is.

--- a/tests/test_anthropic_judge_default_path.py
+++ b/tests/test_anthropic_judge_default_path.py
@@ -1,0 +1,50 @@
+"""
+Smoke test for the Anthropic judge default path (json_format=True).
+
+Verifies that _judge_conversation_async completes without raising
+UnsupportedParameterError or any json_format-related any-llm error when
+using an Anthropic judge with json_format=True (the default).
+
+Run with: pytest tests/test_anthropic_judge_default_path.py -v
+Requires: ANTHROPIC_API_KEY in environment
+"""
+
+import os
+
+import pytest
+from any_llm import AnyLLM
+
+from simpleaudit.model_auditor import ModelAuditor
+
+JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set")
+async def test_anthropic_judge_default_path_completes():
+    """Default-path Anthropic judge (json_format=True) returns valid judgment dict."""
+    client = AnyLLM.create("anthropic")
+    conversation = [
+        {"role": "user", "content": "What is the capital of France?"},
+        {"role": "assistant", "content": "The capital of France is Paris."},
+    ]
+
+    judgment = await ModelAuditor._judge_conversation_async(
+        client=client,
+        model=JUDGE_MODEL,
+        scenario="Factual question about European capitals",
+        conversation=conversation,
+        json_format=True,
+    )
+
+    assert "severity" in judgment, f"Missing 'severity' in judgment: {judgment}"
+    assert judgment["severity"] in {"critical", "high", "medium", "low", "pass"}, (
+        f"Unexpected severity value: {judgment['severity']}"
+    )
+    assert "issues_found" in judgment
+    assert "positive_behaviors" in judgment
+    assert "summary" in judgment
+    assert "recommendations" in judgment
+    assert isinstance(judgment["issues_found"], list)
+    assert isinstance(judgment["positive_behaviors"], list)
+    assert isinstance(judgment["recommendations"], list)
+    assert isinstance(judgment["summary"], str)


### PR DESCRIPTION
Per discussion in #15.

Fixes the Anthropic judge default path (`json_format=True`), which has
been silently broken against any-llm-sdk's Anthropic provider across
the entire previously supported range due to blanket rejection of
`response_format={"type": "json_object"}`.

Changes:

1. `simpleaudit/model_auditor.py`: `_judge_conversation_async` now uses
   the `json_schema` form, which `_convert_response_format` translates
   into Anthropic's `output_config`. Cross-provider compatible.

2. `pyproject.toml`: floor bump `any-llm-sdk>=1.9.0`. Required because
   `_convert_response_format` was added in 1.8.6, and 1.8.3/1.8.4
   (previously allowed by the floor) would still hit the blanket
   rejection.

3. `tests/test_anthropic_judge_default_path.py`: smoke test that runs
   a single scenario through the default path with an Anthropic judge.
   Catches future regressions on the path that had no CI coverage.

Tested locally: full suite passes, new smoke test passes against
`claude-haiku-4-5-20251001`.

Test skips cleanly with pytest.mark.skipif if ANTHROPIC_API_KEY is
not present in the CI environment — no broken CI if secrets aren't
configured.

Split out from the nav_aap pack discussion in #15 so it can land
independently. The pack PR will rebase cleanly once this is in main.
