### PR TITLE
Only list loadable models in experiments

### DIFF
--- a/simpleaudit/visualization/server.py
+++ b/simpleaudit/visualization/server.py
@@ -27,15 +27,44 @@ CONTACT_EMAIL = os.getenv("SIMPLEAUDIT_VISUALIZER_EMAIL", "sushant@simula.no")
 RESULTS_DIR = None
 
 
+def _looks_like_audit_result(obj: object) -> bool:
+    return (
+        isinstance(obj, dict)
+        and ("scenario_name" in obj or "name" in obj)
+        and "severity" in obj
+    )
+
+
+def _experiment_models(data: object) -> List[str]:
+    """Model labels in an experiment file that have at least one loadable run.
+
+    A run is loadable when it is a dict holding a non-empty list of
+    audit-shaped results. Both the file tree and the JSON endpoint derive
+    their notion of "experiment" from this list, so the tree never shows an
+    entry (file or model) that the endpoint would refuse to serve.
+    """
+    if not isinstance(data, dict):
+        return []
+    runs = data.get("runs")
+    if not isinstance(runs, dict):
+        return []
+    models = []
+    for label, run_list in runs.items():
+        entries = run_list if isinstance(run_list, list) else [run_list]
+        for entry in entries:
+            if (
+                isinstance(entry, dict)
+                and isinstance(entry.get("results"), list)
+                and entry["results"]
+                and all(_looks_like_audit_result(item) for item in entry["results"])
+            ):
+                models.append(label)
+                break
+    return models
+
+
 def is_valid_audit_data(data) -> bool:
     """Check whether parsed JSON has the shape of audit results."""
-
-    def _looks_like_audit_result(obj: object) -> bool:
-        return (
-            isinstance(obj, dict)
-            and ("scenario_name" in obj or "name" in obj)
-            and "severity" in obj
-        )
 
     # Legacy shape: a list[AuditResult]
     if isinstance(data, list):
@@ -52,17 +81,7 @@ def is_valid_audit_data(data) -> bool:
 
     # Multi-model experiment shape: {"runs": {"model": [{"results": [...]}]}}
     if isinstance(data, dict) and "runs" in data:
-        runs = data["runs"]
-        if not isinstance(runs, dict) or not runs:
-            return False
-        for run_list in runs.values():
-            entries = run_list if isinstance(run_list, list) else [run_list]
-            for entry in entries:
-                if isinstance(entry, dict) and "results" in entry:
-                    results = entry["results"]
-                    if isinstance(results, list) and results:
-                        return True
-        return False
+        return bool(_experiment_models(data))
 
     return False
 
@@ -125,13 +144,13 @@ def get_file_tree(directory: str, base_path: str = "") -> List[Dict]:
                     data = json.load(f)
             except Exception:
                 continue
-            runs = data.get('runs') if isinstance(data, dict) else None
-            if isinstance(runs, dict) and runs:
+            experiment_models = _experiment_models(data)
+            if experiment_models:
                 items.append({
                     "name": entry,
                     "type": "experiment",
                     "path": rel_path,
-                    "models": list(runs.keys())
+                    "models": experiment_models
                 })
             elif is_valid_audit_data(data):
                 items.append({

--- a/simpleaudit/visualization/visualizer.html
+++ b/simpleaudit/visualization/visualizer.html
@@ -710,6 +710,9 @@
                 fileDiv.innerHTML = `<span class="file-icon text-base"></span><span class="flex-1 text-gray-700 ${isSelected ? 'font-semibold' : ''}">${escapeHtml(model)}</span>`;
                 fileDiv.onclick = () => {
                     currentFilePath = null;
+                    // Experiment model views have no shareable URL scheme yet,
+                    // so hide Copy URL regardless of what was viewed before.
+                    window.__customUpload = true;
                     currentExperimentSelection = selectionKey;
                     applyTreeSelectionState(fileDiv);
                     loadModel(model);
@@ -746,10 +749,13 @@
                 try {
                     const data = JSON.parse(e.target.result);
                     
-                    // Clear file tree selection since this is a custom upload
+                    // Clear file tree selection since this is a custom upload;
+                    // also drop any previously uploaded experiment so its
+                    // folder does not linger in the tree.
                     currentFilePath = null;
                     currentExperimentSelection = null;
-                    
+                    uploadedExperiment = null;
+
                     // Update file tree to clear any selection
                     loadFileTree();
                     
@@ -828,11 +834,30 @@
 
         // --- Data Processing ---
 
+        // Model labels in an experiment file that have at least one loadable
+        // run (an object with a non-empty results array). Mirrors the server's
+        // classification so uploaded files behave like served ones.
+        function experimentModels(data) {
+            if (!data || typeof data !== 'object' || Array.isArray(data)) return [];
+            const runs = data.runs;
+            if (!runs || typeof runs !== 'object' || Array.isArray(runs)) return [];
+            return Object.keys(runs).filter(model => {
+                const entries = Array.isArray(runs[model]) ? runs[model] : [runs[model]];
+                return entries.some(entry => entry && typeof entry === 'object'
+                    && Array.isArray(entry.results) && entry.results.length > 0);
+            });
+        }
+
         function appendExperimentToTree(data, filename) {
-            const folderDiv = renderExperimentFolder(filename, `upload::${filename}`, Object.keys(data.runs), (model) => {
-                const runs = data.runs[model];
-                processData(Array.isArray(runs) ? runs[0] : runs, `${filename} \u2014 ${model}`, true);
-            }, true);
+            const key = `upload::${filename}`;
+            const folderDiv = renderExperimentFolder(filename, key, experimentModels(data), (model) => {
+                try {
+                    const runs = data.runs[model];
+                    processData(Array.isArray(runs) ? runs[0] : runs, `${filename} \u2014 ${model}`, true);
+                } catch (e) {
+                    document.getElementById('file-info').textContent = `Error: ${e.message}`;
+                }
+            }, expandedFolders.has(key));
             document.getElementById('file-tree').appendChild(folderDiv);
         }
 
@@ -842,10 +867,19 @@
                 allScenarios = data;
             } else if (data.results && Array.isArray(data.results)) {
                 allScenarios = data.results;
-            } else if (data.runs && typeof data.runs === 'object') {
+            } else if (experimentModels(data).length > 0) {
                 // Multi-model results from AuditExperiment — show models in the sidebar
-                uploadedExperiment = { data, filename };
-                appendExperimentToTree(data, filename);
+                if (isCustomUpload) {
+                    uploadedExperiment = { data, filename };
+                    expandedFolders.add(`upload::${filename}`);
+                    appendExperimentToTree(data, filename);
+                } else if (currentFilePath) {
+                    // Server experiment opened directly (e.g. via a ?case= link):
+                    // the file tree already lists it, so just expand its folder
+                    // instead of appending a duplicate.
+                    expandedFolders.add(currentFilePath);
+                    loadFileTree();
+                }
                 // Show a prompt to select a model
                 document.getElementById('file-info').textContent = `${filename} — select a model`;
                 document.getElementById('scenario-list').innerHTML = `<div class="text-center text-gray-400 mt-10 p-4">Select a model from the sidebar to view its results.</div>`;
@@ -858,7 +892,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                         </svg>
                         <p class="font-semibold mb-2">Invalid JSON Format</p>
-                        <p class="text-sm text-gray-600">Expected a list of results or an object with a "results" array.</p>
+                        <p class="text-sm text-gray-600">Expected a list of results, an object with a "results" array, or an AuditExperiment file with a "runs" object.</p>
                     </div>
                 `;
                 return;
@@ -1074,6 +1108,11 @@
                 const url = new URL(window.location);
                 if (currentFilePath) {
                     url.searchParams.set('case', encodeURIComponent(currentFilePath));
+                } else {
+                    // No file path (experiment model view or upload) — drop any
+                    // stale reference to a previously viewed file so the URL
+                    // never points at the wrong data.
+                    url.searchParams.delete('case');
                 }
                 url.hash = `#${encodeURIComponent(scenario.id)}`;
                 window.history.pushState({scenarioId: scenario.id, case: currentFilePath}, '', url);

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -251,6 +251,46 @@ class TestServerExperimentFiles:
         assert by_name["expt.json"]["type"] == "experiment"
         assert by_name["expt.json"]["models"] == ["model-a"]
 
+    def test_tree_and_endpoint_agree_on_experiment_edge_cases(self, tmp_path, monkeypatch):
+        """The tree must never list an entry the JSON endpoint refuses to serve.
+
+        A dict-valued "runs" key alone must not classify a file as an
+        experiment: empty runs, empty results, non-audit result items, and
+        unrelated JSON that happens to use a "runs" key would then show up in
+        the tree only to 403 on click (and leak names of non-audit files).
+        """
+        server = _load_server()
+        root = tmp_path / "results"
+        root.mkdir()
+        cases = {
+            "empty_run_list.json": {"runs": {"model-a": []}},
+            "empty_results.json": {"runs": {"model-a": [{"results": []}]}},
+            "non_audit_items.json": {"runs": {"model-a": [{"results": [1, 2, 3]}]}},
+            "unrelated_runs_key.json": {"runs": {"sweep-1": {"lr": 0.1}}},
+        }
+        for name, payload in cases.items():
+            (root / name).write_text(json.dumps(payload))
+
+        monkeypatch.setattr(server, "RESULTS_DIR", str(root))
+        assert server.get_file_tree(str(root)) == []
+        for name, payload in cases.items():
+            assert server.is_valid_audit_data(payload) is False
+            with pytest.raises(server.HTTPException) as exc:
+                server.get_json_file(name)
+            assert _http_status(exc) == 403
+
+    def test_tree_lists_only_loadable_models(self, tmp_path):
+        server = _load_server()
+        root = tmp_path / "results"
+        root.mkdir()
+        run = {"results": [{"scenario_name": "s", "severity": "pass"}]}
+        payload = {"runs": {"good": [run], "broken": [], "also-good": [run]}}
+        (root / "expt.json").write_text(json.dumps(payload))
+
+        tree = server.get_file_tree(str(root))
+        assert tree[0]["type"] == "experiment"
+        assert tree[0]["models"] == ["good", "also-good"]
+
 
 class TestServerSecret:
     def test_no_secret_is_noop(self, monkeypatch):


### PR DESCRIPTION
Introduce robust experiment validation and ensure the file tree only shows experiment models that contain at least one loadable run. Add _looks_like_audit_result and _experiment_models helpers in the server, and use them in is_valid_audit_data and get_file_tree so the tree never lists entries the JSON endpoint would refuse to serve. Mirror this logic in the client visualizer (experimentModels and related UI changes), improve upload/URL handling and error messaging, and add tests covering experiment edge cases and model filtering.