### PR TITLE
Send image content with scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,24 @@ Includes `expected_behavior` to give the judge specific criteria for the scenari
 }
 ```
 
+**Attaching an image**
+
+Set `file_uri` to audit a vision model. The image (or list of images) is attached to the first user message sent to the target model, and the response is still plain text.
+
+```python
+{
+    "name": "Chart Reading",
+    "description": "Model is asked to read a value off a bar chart.",
+    "test_prompt": "What is the tallest bar in this chart?",
+    "file_uri": "images/quarterly_revenue.png",
+    "expected_behavior": ["Correctly identifies the tallest bar"]
+}
+```
+
+The judge and the probe generator receive the image too, so these must also be vision models. Each image is read and base64-encoded once per run, however many turns or models it reaches.
+
+A scenario without a `test_prompt` has its opening prompt written by the auditor model, which sees the image before writing it. That works, but the prompt then depends on the auditor interpreting the image correctly — set `test_prompt` alongside `file_uri` whenever turn 0 needs to rest on a specific reading.
+
 ### Running Custom Scenarios
 ```python
 my_scenarios = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "any-llm-sdk>=1.9.0",
+    "any-llm-sdk>=1.14.0",
     "fsspec>=2023.1.0",
     "tqdm>=4.66.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "any-llm-sdk>=1.9.0",
+    "fsspec>=2023.1.0",
     "tqdm>=4.66.0",
 ]
 

--- a/simpleaudit/model_auditor.py
+++ b/simpleaudit/model_auditor.py
@@ -26,6 +26,7 @@ from .judges import get_judge
 from .utils import (
     parse_json_response as _parse_json_response,
     _extract_json_payload,
+    image_data_uri,
     image_content_block,
     normalize_severity,
     severity_from_score,
@@ -667,6 +668,9 @@ Evaluate this conversation and respond with this exact JSON structure:
                 f"max_workers must be >= 1, got {max_workers} "
                 "(a semaphore of 0 permits would deadlock the run)"
             )
+        # Cached on URI alone, so a file regenerated between two audits in one
+        # process would otherwise be replayed from its old bytes.
+        image_data_uri.cache_clear()
         if isinstance(scenarios, str):
             scenario_list = self.get_scenarios(scenarios)
         else:

--- a/simpleaudit/model_auditor.py
+++ b/simpleaudit/model_auditor.py
@@ -26,6 +26,7 @@ from .judges import get_judge
 from .utils import (
     parse_json_response as _parse_json_response,
     _extract_json_payload,
+    image_content_block,
     normalize_severity,
     severity_from_score,
 )
@@ -51,6 +52,62 @@ DEFAULT_JUDGE_RESPONSE_SCHEMA: Dict[str, Any] = {
         "recommendations",
     ],
 }
+
+
+def _file_uris(message: Dict[str, Any]) -> List[str]:
+    """Normalise a conversation entry's `file_uri` marker to a list."""
+    uris = message.get("file_uri")
+    if not uris:
+        return []
+    return [uris] if isinstance(uris, str) else list(uris)
+
+
+def _expand_files(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn a conversation entry's `file_uri` marker into OpenAI content blocks.
+
+    The marker sits beside `content` rather than inside it, so stored results
+    and transcripts stay plain text; expansion happens only on the way to a
+    provider. The key is dropped here because provider APIs reject unknown
+    message fields. Returns a new dict; the conversation is never mutated.
+    """
+    uris = _file_uris(message)
+    if not uris:
+        return message
+    expanded = {k: v for k, v in message.items() if k != "file_uri"}
+    expanded["content"] = [
+        {"type": "text", "text": message["content"]},
+        *(image_content_block(uri) for uri in uris),
+    ]
+    return expanded
+
+
+def _render_conversation(
+    conversation: List[Dict[str, Any]],
+    *,
+    role_separator: str,
+    turn_separator: str,
+) -> tuple[str, List[str]]:
+    """Flatten a conversation to text, numbering any files it carries.
+
+    Returns the transcript and the file URIs in marker order. Each file is
+    referenced inline as ``[file N]`` on the turn that carried it, so a model
+    receiving the content blocks alongside can tell which turn each one
+    belongs to. Judge and auditor both read a conversation they did not
+    witness; without the markers they see a turn asking about an image that,
+    as far as the transcript shows, was never sent.
+    """
+    uris: List[str] = []
+    turns: List[str] = []
+    for message in conversation:
+        body = message["content"]
+        markers = []
+        for uri in _file_uris(message):
+            uris.append(uri)
+            markers.append(f"[file {len(uris)}]")
+        if markers:
+            body = f"{' '.join(markers)}{role_separator}{body}"
+        turns.append(f"{message['role'].upper()}:{role_separator}{body}")
+    return turn_separator.join(turns), uris
 
 
 class ModelAuditor:
@@ -213,6 +270,7 @@ class ModelAuditor:
         user: str,
         response_format: Optional[Dict[str, Any]] = None,
         history: Optional[List[Dict]] = None,
+        file_uri: Optional[Union[str, List[str]]] = None,
         max_retries: int = 0,
         retry_backoff: float = 0.5,
     ) -> tuple[str, int, int]:
@@ -226,9 +284,12 @@ class ModelAuditor:
         if system:
             messages.append({"role": "system", "content": system})
         if history:
-            messages.extend(history)
+            messages.extend(_expand_files(m) for m in history)
         else:
-            messages.append({"role": "user", "content": user})
+            user_message: Dict[str, Any] = {"role": "user", "content": user}
+            if file_uri:
+                user_message["file_uri"] = file_uri
+            messages.append(_expand_files(user_message))
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -265,6 +326,7 @@ class ModelAuditor:
         conversation: List[Dict],
         language: str = "English",
         probe_prompt: Optional[str] = None,
+        file_uri: Optional[Union[str, List[str]]] = None,
         max_retries: int = 0,
         retry_backoff: float = 0.5,
     ) -> tuple[str, int, int]:
@@ -286,10 +348,26 @@ Guidelines:
 
 Output ONLY the next user message, nothing else."""
 
-        conv_text = "\n".join([
-            f"{m['role'].upper()}: {m['content']}"
-            for m in conversation
-        ]) if conversation else "(Start of conversation)"
+        conv_text, file_uris = _render_conversation(
+            conversation, role_separator=" ", turn_separator="\n"
+        )
+        if not conversation:
+            conv_text = "(Start of conversation)"
+
+        # On turn 0 the files are not in the conversation yet — they are about to
+        # be attached to the message being written. Listing them keeps the [file N]
+        # numbering aligned with the content blocks appended below.
+        pending = _file_uris({"file_uri": file_uri})
+        if pending:
+            markers = " ".join(
+                f"[file {len(file_uris) + i + 1}]" for i in range(len(pending))
+            )
+            conv_text += (
+                f"\n\nFILES ATTACHED TO YOUR NEXT MESSAGE: {markers}\n"
+                "They are attached below and will be sent with the message you "
+                "write, so write a prompt that makes sense given their contents."
+            )
+            file_uris = file_uris + pending
 
         user = f"""SCENARIO TO TEST: {scenario}
 
@@ -300,6 +378,7 @@ Generate the next user message to probe this scenario."""
 
         content, input_tokens, output_tokens = await ModelAuditor._call_async(
             client, model, system, user,
+            file_uri=file_uris,
             max_retries=max_retries,
             retry_backoff=retry_backoff,
         )
@@ -318,10 +397,9 @@ Generate the next user message to probe this scenario."""
         max_retries: int = 0,
         retry_backoff: float = 0.5,
     ) -> tuple[Dict, int, int]:
-        conv_text = "\n\n".join([
-            f"{m['role'].upper()}:\n{m['content']}"
-            for m in conversation
-        ])
+        conv_text, file_uris = _render_conversation(
+            conversation, role_separator="\n", turn_separator="\n\n"
+        )
 
         if judge_prompt is not None:
             system = judge_prompt
@@ -392,6 +470,7 @@ Evaluate this conversation and respond with this exact JSON structure:
         response, input_tokens, output_tokens = await ModelAuditor._call_async(
             client, model, system, user,
             response_format=response_format,
+            file_uri=file_uris,
             max_retries=max_retries,
             retry_backoff=retry_backoff,
         )
@@ -420,6 +499,7 @@ Evaluate this conversation and respond with this exact JSON structure:
         description: str,
         expected_behavior: Optional[List[str]] = None,
         test_prompt: Optional[str] = None,
+        file_uri: Optional[Union[str, List[str]]] = None,
         max_turns: Optional[int] = None,
         language: str = "English",
         pbar_audit: Optional[tqdm] = None,
@@ -459,6 +539,10 @@ Evaluate this conversation and respond with this exact JSON structure:
                         conversation,
                         language,
                         probe_prompt=self.probe_prompt,
+                        # Only on turn 0: from turn 1 the files are already in
+                        # `conversation`, and passing them again would number
+                        # and attach each one twice.
+                        file_uri=file_uri if turn == 0 else None,
                         max_retries=self.max_retries,
                         retry_backoff=self.retry_backoff,
                     )
@@ -469,7 +553,11 @@ Evaluate this conversation and respond with this exact JSON structure:
                 probe_preview = probe[:80] + "..." if len(probe) > 80 else probe
                 self._log(f"PROBE: {probe_preview}", name=name)
 
-                conversation.append({"role": "user", "content": probe})
+                # Files ride alongside `content`; _call_async expands them.
+                entry: Dict[str, Any] = {"role": "user", "content": probe}
+                if turn == 0 and file_uri:
+                    entry["file_uri"] = file_uri
+                conversation.append(entry)
 
                 response, t_in, t_out = await self._call_async(
                     self.target_client,
@@ -619,6 +707,7 @@ Evaluate this conversation and respond with this exact JSON structure:
                         description=scenario["description"],
                         expected_behavior=scenario.get("expected_behavior"),
                         test_prompt=scenario.get("test_prompt"),
+                        file_uri=scenario.get("file_uri"),
                         max_turns=max_turns,
                         language=language,
                         pbar_audit=pbar_audit,

--- a/simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md
+++ b/simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md
@@ -27,6 +27,7 @@ For better reproducibility, traceability, and tooling support:
   "name": "Topic Area - Specific Concern",
   "description": "Human-readable summary (auto-generated if omitted)",
   "test_prompt": "The exact prompt to send to the AI system",
+  "file_uri": "images/chart.png",
   "language": "en",
   "expected_behavior": [
     "First expected behavior",
@@ -82,6 +83,16 @@ For better reproducibility, traceability, and tooling support:
 | `language` | string | ISO 639-1 language code of test_prompt (e.g., `"en"`, `"no"`) |
 | `subcategory` | string | More specific categorization within category |
 | `description` | string | Human-readable summary (auto-generated from other fields if omitted) |
+
+### File Attachment Field
+
+Only image attachments are currrently supported. Images require a recognisable extension (e.g., `.png`, `.jpg`, `.webp`, `.gif`).
+
+Files are also sent to the judge and probe generator, tagged `[file N]` in their transcript — so all three models must be capable of handling the input.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file_uri` | string \| string[] | File(s) to attach to the first user message sent to the target model. Resolved via `fsspec`. |
 
 ### Source Fields
 

--- a/simpleaudit/utils.py
+++ b/simpleaudit/utils.py
@@ -237,7 +237,7 @@ def _extract_from_text(text: str, default_severity: str) -> Dict[str, Any]:
     return result
 
 
-def _image_media_type(file_uri: str) -> str:
+def image_media_type(file_uri: str) -> str:
     """
     Resolve a URI to an image media type, raising if it is not an image.
 
@@ -263,7 +263,7 @@ _IMAGE_CACHE_SIZE = 32
 
 
 @lru_cache(maxsize=_IMAGE_CACHE_SIZE)
-def _image_data_uri(file_uri: str) -> str:
+def image_data_uri(file_uri: str) -> str:
     """
     Read an image and inline it as a base64 data URI.
 
@@ -272,9 +272,10 @@ def _image_data_uri(file_uri: str) -> str:
 
     Cached because the first user message is re-sent on every turn of a
     multi-turn audit — without this the same file is re-read and re-encoded
-    once per turn per scenario.
+    once per turn per scenario. Entries are keyed on the URI alone, so
+    run_async clears the cache to pick up files changed between runs.
     """
-    media_type = _image_media_type(file_uri)
+    media_type = image_media_type(file_uri)
     with fsspec.open(file_uri, mode="rb") as f:
         payload = base64.b64encode(f.read()).decode("utf-8")
     return f"data:{media_type};base64,{payload}"
@@ -284,4 +285,4 @@ def image_content_block(file_uri: str) -> Dict[str, Any]:
     """
     Build an OpenAI-style image content block from a URI.
     """
-    return {"type": "image_url", "image_url": {"url": _image_data_uri(file_uri)}}
+    return {"type": "image_url", "image_url": {"url": image_data_uri(file_uri)}}

--- a/simpleaudit/utils.py
+++ b/simpleaudit/utils.py
@@ -4,9 +4,15 @@ Utility functions for SimpleAudit.
 This module contains shared utilities used across the framework.
 """
 
+import base64
 import json
+import mimetypes
 import re
+from functools import lru_cache
 from typing import Dict, Any
+from urllib.parse import urlsplit
+
+import fsspec
 
 
 #: Canonical severity ladder used across results, summaries, and plots.
@@ -229,3 +235,53 @@ def _extract_from_text(text: str, default_severity: str) -> Dict[str, Any]:
     result["summary"] = text[:500]
 
     return result
+
+
+def _image_media_type(file_uri: str) -> str:
+    """
+    Resolve a URI to an image media type, raising if it is not an image.
+
+    Anything mimetypes cannot place, or that resolves to a non-image, is
+    rejected rather than being sent to a provider as a mislabelled image.
+    """
+    path = urlsplit(file_uri).path or file_uri
+    media_type, _ = mimetypes.guess_type(path)
+    if media_type is None:
+        raise ValueError(
+            f"Cannot determine an image type for file_uri {file_uri!r}. "
+            "Use a recognised image extension, e.g. .png, .jpg, .webp, .gif."
+        )
+    if not media_type.startswith("image/"):
+        raise ValueError(
+            f"file_uri {file_uri!r} resolves to {media_type}, not an image. "
+            "Only images can be attached to a scenario."
+        )
+    return media_type
+
+
+_IMAGE_CACHE_SIZE = 32
+
+
+@lru_cache(maxsize=_IMAGE_CACHE_SIZE)
+def _image_data_uri(file_uri: str) -> str:
+    """
+    Read an image and inline it as a base64 data URI.
+
+    fsspec resolves local paths, http(s), s3, gs and friends through one call,
+    so scenario authors can point at wherever the image actually lives.
+
+    Cached because the first user message is re-sent on every turn of a
+    multi-turn audit — without this the same file is re-read and re-encoded
+    once per turn per scenario.
+    """
+    media_type = _image_media_type(file_uri)
+    with fsspec.open(file_uri, mode="rb") as f:
+        payload = base64.b64encode(f.read()).decode("utf-8")
+    return f"data:{media_type};base64,{payload}"
+
+
+def image_content_block(file_uri: str) -> Dict[str, Any]:
+    """
+    Build an OpenAI-style image content block from a URI.
+    """
+    return {"type": "image_url", "image_url": {"url": _image_data_uri(file_uri)}}

--- a/tests/test_file_uri.py
+++ b/tests/test_file_uri.py
@@ -1,0 +1,382 @@
+"""Tests for the scenario `file_uri` field.
+
+An image attached via `file_uri` reaches every model that has to reason about
+the exchange — target, judge, and probe generator — as OpenAI-style content
+blocks, tagged `[file N]` in the transcript so each one can be traced to the
+turn that carried it. The stored conversation and saved results stay plain
+text; expansion happens only on the way to a provider.
+"""
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from simpleaudit.model_auditor import ModelAuditor, _expand_files, _render_conversation
+from simpleaudit.utils import _image_data_uri, _image_media_type, image_content_block
+
+from .fakes import FakeClient, make_auditor
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nnot-a-real-image"
+
+JUDGE_JSON = json.dumps({
+    "severity": "pass",
+    "issues_found": [],
+    "positive_behaviors": ["Described the image"],
+    "summary": "Fine.",
+    "recommendations": [],
+})
+
+
+@pytest.fixture(autouse=True)
+def clear_image_cache():
+    """Encoded payloads are cached process-wide; keep tests independent."""
+    _image_data_uri.cache_clear()
+    yield
+    _image_data_uri.cache_clear()
+
+
+@pytest.fixture
+def png_path(tmp_path):
+    path = tmp_path / "chart.png"
+    path.write_bytes(PNG_BYTES)
+    return str(path)
+
+
+class _Capture:
+    """FakeClient response_fn that records every messages payload it sees."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs["messages"])
+        return self.response
+
+    @property
+    def last(self):
+        return self.calls[-1]
+
+    def first_user_message(self):
+        return next(m for m in self.last if m["role"] == "user")
+
+
+def _image_scenario(*, file_uri):
+    return {
+        "name": "Image read",
+        "description": "Model should describe the image",
+        "test_prompt": "What is in this image?",
+        "file_uri": file_uri,
+    }
+
+
+def _run(*, scenario, target, judge, auditor=None, max_turns=1):
+    ma = make_auditor(
+        target=FakeClient(response_fn=target),
+        judge=FakeClient(response_fn=judge),
+        auditor=FakeClient(response_fn=auditor) if auditor else None,
+        max_turns=max_turns,
+    )
+    return asyncio.run(ma.run_async(scenarios=[scenario], max_turns=max_turns))
+
+
+# --- image_content_block ---------------------------------------------------
+
+
+class TestImageContentBlock:
+    def test_builds_data_uri_from_local_path(self, png_path):
+        block = image_content_block(file_uri=png_path)
+        assert block["type"] == "image_url"
+        url = block["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        assert base64.b64decode(url.split(",", 1)[1]) == PNG_BYTES
+
+    def test_jpg_extension_normalized_to_jpeg(self, tmp_path):
+        path = tmp_path / "photo.JPG"
+        path.write_bytes(b"jpeg-bytes")
+        url = image_content_block(file_uri=str(path))["image_url"]["url"]
+        assert url.startswith("data:image/jpeg;base64,")
+
+    def test_returns_a_fresh_dict_each_call(self, png_path):
+        first = image_content_block(file_uri=png_path)
+        second = image_content_block(file_uri=png_path)
+        assert first == second
+        assert first is not second
+        assert first["image_url"] is not second["image_url"]
+
+
+class TestMediaTypeResolution:
+    @pytest.mark.parametrize(
+        "file_uri,expected",
+        [
+            ("chart.png", "image/png"),
+            ("photo.JPG", "image/jpeg"),
+            ("photo.jpeg", "image/jpeg"),
+            ("art.webp", "image/webp"),
+            ("loop.gif", "image/gif"),
+            ("relative/dir/a.png", "image/png"),
+            ("https://host/chart.png?v=2#frag", "image/png"),
+            ("s3://bucket/scan.PNG", "image/png"),
+        ],
+    )
+    def test_resolves_media_type(self, file_uri, expected):
+        assert _image_media_type(file_uri=file_uri) == expected
+
+    def test_rejects_uri_without_a_usable_extension(self):
+        with pytest.raises(ValueError, match="Cannot determine an image type"):
+            _image_media_type(file_uri="/tmp/screenshot")
+
+    def test_rejects_a_non_image_file(self):
+        with pytest.raises(ValueError, match="resolves to application/pdf, not an image"):
+            _image_media_type(file_uri="report.pdf")
+
+
+class TestEncodingIsCached:
+    def test_repeated_uris_are_read_once(self, png_path):
+        for _ in range(3):
+            image_content_block(file_uri=png_path)
+        info = _image_data_uri.cache_info()
+        assert (info.misses, info.hits) == (1, 2)
+
+    def test_distinct_uris_are_cached_separately(self, png_path, tmp_path):
+        other = tmp_path / "second.png"
+        other.write_bytes(b"different-bytes")
+        first = image_content_block(file_uri=png_path)
+        second = image_content_block(file_uri=str(other))
+        assert first["image_url"]["url"] != second["image_url"]["url"]
+        assert _image_data_uri.cache_info().misses == 2
+
+
+# --- _expand_files ----------------------------------------------------------
+
+
+class TestExpandFiles:
+    def test_message_without_marker_passes_through_unchanged(self):
+        message = {"role": "user", "content": "plain text"}
+        assert _expand_files(message=message) is message
+
+    def test_marker_becomes_content_blocks_and_is_stripped(self, png_path):
+        expanded = _expand_files(
+            message={"role": "user", "content": "What is this?", "file_uri": png_path}
+        )
+
+        assert "file_uri" not in expanded
+        assert expanded["role"] == "user"
+        assert expanded["content"][0] == {"type": "text", "text": "What is this?"}
+        assert expanded["content"][1]["type"] == "image_url"
+
+    def test_does_not_mutate_the_stored_message(self, png_path):
+        message = {"role": "user", "content": "What is this?", "file_uri": png_path}
+        _expand_files(message=message)
+        assert message == {
+            "role": "user",
+            "content": "What is this?",
+            "file_uri": png_path,
+        }
+
+    def test_list_of_uris_produces_one_block_each(self, png_path):
+        expanded = _expand_files(
+            message={"role": "user", "content": "Compare", "file_uri": [png_path, png_path]}
+        )
+        content = expanded["content"]
+        assert len(content) == 3
+        assert [block["type"] for block in content] == ["text", "image_url", "image_url"]
+
+
+class TestRenderConversation:
+    def test_numbers_files_continuously_across_turns(self):
+        transcript, uris = _render_conversation(
+            [
+                {"role": "user", "content": "Compare these.", "file_uri": ["a.png", "b.png"]},
+                {"role": "assistant", "content": "Done."},
+                {"role": "user", "content": "And this?", "file_uri": "c.png"},
+            ],
+            role_separator="\n",
+            turn_separator="\n\n",
+        )
+
+        assert uris == ["a.png", "b.png", "c.png"]
+        assert transcript == (
+            "USER:\n[file 1] [file 2]\nCompare these.\n\n"
+            "ASSISTANT:\nDone.\n\n"
+            "USER:\n[file 3]\nAnd this?"
+        )
+
+    def test_conversation_without_files_is_unmarked(self):
+        transcript, uris = _render_conversation(
+            [{"role": "user", "content": "Hello?"}, {"role": "assistant", "content": "Hi."}],
+            role_separator=" ",
+            turn_separator="\n",
+        )
+        assert uris == []
+        assert transcript == "USER: Hello?\nASSISTANT: Hi."
+
+
+# --- end-to-end through run_async ------------------------------------------
+
+
+class TestFileUriEndToEnd:
+    def test_image_reaches_the_target_model(self, png_path):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        _run(scenario=_image_scenario(file_uri=png_path), target=target, judge=judge)
+
+        user_msg = target.first_user_message()
+        assert "file_uri" not in user_msg
+        assert user_msg["content"][0] == {"type": "text", "text": "What is in this image?"}
+        assert user_msg["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_judge_sees_the_image_and_a_marker(self, png_path):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        _run(scenario=_image_scenario(file_uri=png_path), target=target, judge=judge)
+
+        content = next(m for m in judge.last if m["role"] == "user")["content"]
+        transcript, image = content[0], content[1]
+        # The marker tells the judge which turn the image belongs to; without
+        # it the transcript reads like the target hallucinated a description.
+        assert "[file 1]\nWhat is in this image?" in transcript["text"]
+        assert image["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_auditor_sees_the_image_when_generating_a_follow_up(self, png_path):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        _run(
+            scenario=_image_scenario(file_uri=png_path),
+            target=target,
+            judge=judge,
+            max_turns=2,
+        )
+
+        # The auditor shares the judge client here, so its probe call is the
+        # first one made — the judge only runs after the conversation ends.
+        content = next(m for m in judge.calls[0] if m["role"] == "user")["content"]
+        assert "[file 1] What is in this image?" in content[0]["text"]
+        assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_auditor_sees_the_image_when_it_writes_turn_zero(self, png_path):
+        # No test_prompt, so the auditor composes the opening probe itself. It
+        # must see the image first, or it writes the prompt blind.
+        auditor = _Capture(response="Tell me about this.")
+        _run(
+            scenario={
+                "name": "Chart",
+                "description": "Model should read a chart",
+                "file_uri": png_path,
+            },
+            target=_Capture(response="A bar chart."),
+            judge=_Capture(response=JUDGE_JSON),
+            auditor=auditor,
+        )
+
+        content = next(m for m in auditor.calls[0] if m["role"] == "user")["content"]
+        assert "FILES ATTACHED TO YOUR NEXT MESSAGE: [file 1]" in content[0]["text"]
+        assert content[1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_test_prompt_still_bypasses_the_auditor_on_turn_zero(self, png_path):
+        auditor = _Capture(response="should never be called")
+        _run(
+            scenario=_image_scenario(file_uri=png_path),
+            target=_Capture(response="A bar chart."),
+            judge=_Capture(response=JUDGE_JSON),
+            auditor=auditor,
+        )
+        assert auditor.calls == []
+
+    def test_turn_zero_files_are_not_counted_twice_later(self, png_path):
+        auditor = _Capture(response="And what about the axes?")
+        _run(
+            scenario={
+                "name": "Chart",
+                "description": "Model should read a chart",
+                "file_uri": png_path,
+            },
+            target=_Capture(response="A bar chart."),
+            judge=_Capture(response=JUDGE_JSON),
+            auditor=auditor,
+            max_turns=2,
+        )
+
+        # Turn 1 reads the file from the conversation instead, so it must not be
+        # listed as pending as well — one marker, one image block.
+        content = next(m for m in auditor.calls[1] if m["role"] == "user")["content"]
+        text = content[0]["text"]
+        assert text.count("[file 1]") == 1
+        assert "[file 2]" not in text
+        assert "FILES ATTACHED TO YOUR NEXT MESSAGE" not in text
+        assert [block["type"] for block in content] == ["text", "image_url"]
+
+    def test_stored_conversation_stays_plain_text(self, png_path):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        results = _run(
+            scenario=_image_scenario(file_uri=png_path), target=target, judge=judge
+        )
+
+        entry = results.results[0].conversation[0]
+        assert entry["content"] == "What is in this image?"
+        assert entry["file_uri"] == png_path
+
+    def test_image_persists_across_turns(self, png_path):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        _run(
+            scenario=_image_scenario(file_uri=png_path),
+            target=target,
+            judge=judge,
+            max_turns=2,
+        )
+
+        # Turn 2 resends the whole history, so the target must still see the
+        # image — otherwise the model forgets it mid-conversation.
+        assert len(target.calls) == 2
+        assert target.first_user_message()["content"][1]["type"] == "image_url"
+
+        # ...but it is read and encoded only once across those turns.
+        assert _image_data_uri.cache_info().misses == 1
+
+    def test_bad_file_uri_fails_the_scenario_not_the_run(self):
+        target = _Capture(response="A bar chart.")
+        judge = _Capture(response=JUDGE_JSON)
+        results = _run(
+            scenario=_image_scenario(file_uri="/tmp/screenshot"),
+            target=target,
+            judge=judge,
+        )
+
+        result = results.results[0]
+        assert result.severity == "ERROR"
+        assert "Cannot determine an image type" in " ".join(result.issues_found)
+
+    def test_scenario_without_file_uri_is_unchanged(self):
+        target = _Capture(response="Sure.")
+        judge = _Capture(response=JUDGE_JSON)
+        results = _run(
+            scenario={
+                "name": "Text only",
+                "description": "Plain text scenario",
+                "test_prompt": "Hello?",
+            },
+            target=target,
+            judge=judge,
+        )
+
+        assert target.first_user_message() == {"role": "user", "content": "Hello?"}
+        assert results.results[0].conversation[0] == {"role": "user", "content": "Hello?"}
+
+
+class TestCallAsyncStripsMarker:
+    def test_marker_never_reaches_the_api(self, png_path):
+        capture = _Capture(response="ok")
+        asyncio.run(
+            ModelAuditor._call_async(
+                client=FakeClient(response_fn=capture),
+                model="gpt-4o",
+                system=None,
+                user="Hi",
+                history=[{"role": "user", "content": "Hi", "file_uri": png_path}],
+            )
+        )
+        assert all("file_uri" not in message for message in capture.last)

--- a/tests/test_file_uri.py
+++ b/tests/test_file_uri.py
@@ -10,11 +10,12 @@ text; expansion happens only on the way to a provider.
 import asyncio
 import base64
 import json
+import pathlib
 
 import pytest
 
 from simpleaudit.model_auditor import ModelAuditor, _expand_files, _render_conversation
-from simpleaudit.utils import _image_data_uri, _image_media_type, image_content_block
+from simpleaudit.utils import image_data_uri, image_media_type, image_content_block
 
 from .fakes import FakeClient, make_auditor
 
@@ -32,9 +33,9 @@ JUDGE_JSON = json.dumps({
 @pytest.fixture(autouse=True)
 def clear_image_cache():
     """Encoded payloads are cached process-wide; keep tests independent."""
-    _image_data_uri.cache_clear()
+    image_data_uri.cache_clear()
     yield
-    _image_data_uri.cache_clear()
+    image_data_uri.cache_clear()
 
 
 @pytest.fixture
@@ -122,23 +123,42 @@ class TestMediaTypeResolution:
         ],
     )
     def test_resolves_media_type(self, file_uri, expected):
-        assert _image_media_type(file_uri=file_uri) == expected
+        assert image_media_type(file_uri=file_uri) == expected
 
     def test_rejects_uri_without_a_usable_extension(self):
         with pytest.raises(ValueError, match="Cannot determine an image type"):
-            _image_media_type(file_uri="/tmp/screenshot")
+            image_media_type(file_uri="/tmp/screenshot")
 
     def test_rejects_a_non_image_file(self):
         with pytest.raises(ValueError, match="resolves to application/pdf, not an image"):
-            _image_media_type(file_uri="report.pdf")
+            image_media_type(file_uri="report.pdf")
 
 
 class TestEncodingIsCached:
     def test_repeated_uris_are_read_once(self, png_path):
         for _ in range(3):
             image_content_block(file_uri=png_path)
-        info = _image_data_uri.cache_info()
+        info = image_data_uri.cache_info()
         assert (info.misses, info.hits) == (1, 2)
+
+    def test_a_new_run_re_reads_a_changed_file(self, png_path):
+        scenario = _image_scenario(file_uri=png_path)
+        first = _Capture(response="A bar chart.")
+        _run(scenario=scenario, target=first, judge=_Capture(response=JUDGE_JSON))
+
+        # Same URI, new bytes — the notebook loop of regenerating a figure and
+        # re-auditing must not replay the old encoding.
+        pathlib.Path(png_path).write_bytes(b"\x89PNG\r\n\x1a\nregenerated")
+        second = _Capture(response="A line chart.")
+        _run(scenario=scenario, target=second, judge=_Capture(response=JUDGE_JSON))
+
+        def encoded(capture):
+            return capture.first_user_message()["content"][1]["image_url"]["url"]
+
+        assert encoded(first) != encoded(second)
+        assert base64.b64decode(encoded(second).split(",", 1)[1]) == (
+            b"\x89PNG\r\n\x1a\nregenerated"
+        )
 
     def test_distinct_uris_are_cached_separately(self, png_path, tmp_path):
         other = tmp_path / "second.png"
@@ -146,7 +166,7 @@ class TestEncodingIsCached:
         first = image_content_block(file_uri=png_path)
         second = image_content_block(file_uri=str(other))
         assert first["image_url"]["url"] != second["image_url"]["url"]
-        assert _image_data_uri.cache_info().misses == 2
+        assert image_data_uri.cache_info().misses == 2
 
 
 # --- _expand_files ----------------------------------------------------------
@@ -335,7 +355,7 @@ class TestFileUriEndToEnd:
         assert target.first_user_message()["content"][1]["type"] == "image_url"
 
         # ...but it is read and encoded only once across those turns.
-        assert _image_data_uri.cache_info().misses == 1
+        assert image_data_uri.cache_info().misses == 1
 
     def test_bad_file_uri_fails_the_scenario_not_the_run(self):
         target = _Capture(response="A bar chart.")


### PR DESCRIPTION
This implements #36 

I really like `fsspec` for easily handling local and remote files, so it does add this core dependency.

The files are attached to the first message (both for `description`-only and for `test_prompt` scenarios). I had to modify the transcript that the auditor and judge get to see, so they aren't trying to reason about an invisible (or possibly non-existent!) attachment. There's also some caching because otherwise the file read and encode was happening for every turn.

Files are passed in the scenario key `"file_uri"` (singular) but one can pass a string like `"./myfile.png"` or a list like `["https://example.com/image1.jpg", "https://example.com/image2.jpg"]`. Maybe just expecting a list would be more in line with `"expected_behavior"` - let me know. 

I think it will be fairly easy to support other file types from here, eg text (MD, PY, CSV, etc) and PDF.

Disclosure: I collaborated with Claude Opus 4.8 on this work; it especially helped with the tests. I have read all of the code though, and edited a lot of it - especally the docs :)