### PR TITLE
Include file attachments in visualizer, fixes #41

### DIFF
--- a/simpleaudit/visualization/scenario_viewer.html
+++ b/simpleaudit/visualization/scenario_viewer.html
@@ -628,6 +628,13 @@
             const history = s.history || [];
             const judgeFeedback = s.reasoning || s.feedback || 'No feedback available.';
 
+            // Attached file(s) sent with the first prompt. Path lives on a
+            // conversation entry (usually turn 0); may be a string or a list.
+            const fileUris = fileUrisFromHistory(history, s);
+            // This is the offline viewer with no backend, so only remote URLs
+            // can be previewed; local paths fall back to a file icon.
+            const standalone = true;
+
             let html = `
                 <div class="max-w-4xl mx-auto space-y-6 pb-20">
                     <!-- Mobile Back Button -->
@@ -651,6 +658,17 @@
                             </div>
                         </div>
                         <p class="text-gray-600 leading-relaxed">${escapeHtml(desc)}</p>
+                        ${fileUris.length ? `
+                        <div class="mt-4 pt-4 border-t border-gray-100">
+                            <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Attached file${fileUris.length > 1 ? 's' : ''}</div>
+                            <div class="space-y-1">
+                                ${fileUris.map(u => `
+                                    <div class="flex items-center gap-2 text-xs text-gray-500">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                                        <code class="font-mono text-gray-600 break-all" title="${escapeHtml(u)}">${escapeHtml(u)}</code>
+                                    </div>`).join('')}
+                            </div>
+                        </div>` : ''}
                     </div>
             `;
 
@@ -677,6 +695,8 @@
                     const role = (turn.role || 'unknown').toUpperCase();
                     const content = turn.content || '';
                     const isUser = role === 'USER' || role === 'HUMAN';
+                    const turnUris = turn.file_uri ? (Array.isArray(turn.file_uri) ? turn.file_uri : [turn.file_uri]) : [];
+                    const contentBlock = `<div class="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap font-mono text-xs bg-gray-50/50 p-2 rounded border border-gray-100">${escapeHtml(content)}</div>`;
 
                     html += `
                         <div class="p-6 ${isUser ? 'bg-white' : 'bg-gray-50'}">
@@ -691,7 +711,8 @@
                                         <h4 class="text-sm font-semibold text-gray-900">${escapeHtml(role)}</h4>
                                         <span class="text-xs text-gray-400">Turn ${idx + 1}</span>
                                     </div>
-                                    <div class="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap font-mono text-xs bg-gray-50/50 p-2 rounded border border-gray-100">${escapeHtml(content)}</div>
+                                    ${contentBlock}
+                                    ${turnUris.length ? `<div class="flex flex-wrap gap-3 mt-2">${turnUris.map(u => attachmentPreview(u, standalone)).join('')}</div>` : ''}
                                 </div>
                             </div>
                         </div>
@@ -751,10 +772,100 @@
                 .replace(/"/g, "&quot;")
                 .replace(/'/g, "&#039;");
         }
+
+        // --- attached-file preview helpers -------------------------------
+        // No backend here, so local paths cannot be previewed; only remote
+        // URLs render a thumbnail, everything else shows a file icon.
+        function fileUrisFromHistory(history, s) {
+            const entry = (history || []).find(t => t && t.file_uri);
+            const raw = entry ? entry.file_uri : (s && s.file_uri);
+            if (!raw) return [];
+            return Array.isArray(raw) ? raw : [raw];
+        }
+
+        function isRemoteUri(uri) {
+            return /^https?:\/\//i.test(String(uri));
+        }
+
+        function isImageUri(uri) {
+            const path = String(uri).split('?')[0].split('#')[0];
+            return /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(path);
+        }
+
+        function fileBaseName(uri) {
+            const path = String(uri).split('?')[0].split('#')[0];
+            const parts = path.split('/');
+            return parts[parts.length - 1] || String(uri);
+        }
+
+        function fileIconBlock(uri, note) {
+            return `
+                <div class="flex items-center gap-2 p-2 rounded border border-gray-200 bg-white max-w-[16rem]">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                    <div class="min-w-0">
+                        <div class="text-xs font-mono text-gray-600 truncate" title="${escapeHtml(uri)}">${escapeHtml(fileBaseName(uri))}</div>
+                        ${note ? `<div class="text-[10px] text-gray-400">${escapeHtml(note)}</div>` : ''}
+                    </div>
+                </div>`;
+        }
+
+        function imagePreviewMarkup(uri, src) {
+            return `
+                <div>
+                    <img src="${escapeHtml(src)}" data-orig-uri="${escapeHtml(uri)}" alt="attached image"
+                         onclick="openLightbox(this.src)" onerror="filePreviewError(this)"
+                         class="file-preview-img max-h-40 rounded border border-gray-200 cursor-pointer bg-white" />
+                    <div class="text-[10px] text-gray-400 font-mono truncate mt-1 max-w-[16rem]" title="${escapeHtml(uri)}">${escapeHtml(fileBaseName(uri))}</div>
+                </div>`;
+        }
+
+        function attachmentPreview(uri, standalone) {
+            if (!isImageUri(uri)) {
+                return fileIconBlock(uri);
+            }
+            if (isRemoteUri(uri)) {
+                return imagePreviewMarkup(uri, uri);
+            }
+            return fileIconBlock(uri, 'Local image — preview unavailable offline');
+        }
+
+        function filePreviewError(img) {
+            const uri = img.getAttribute('data-orig-uri') || '';
+            const wrap = img.closest('div');
+            if (wrap) wrap.outerHTML = fileIconBlock(uri, 'Preview unavailable');
+        }
+
+        function openLightbox(src) {
+            if (!src) return;
+            const ov = document.getElementById('image-lightbox');
+            if (!ov) return;
+            const img = ov.querySelector('img');
+            if (img) img.src = src;
+            ov.classList.remove('hidden');
+            ov.classList.add('flex');
+        }
+
+        function closeLightbox() {
+            const ov = document.getElementById('image-lightbox');
+            if (!ov) return;
+            ov.classList.add('hidden');
+            ov.classList.remove('flex');
+            const img = ov.querySelector('img');
+            if (img) img.src = '';
+        }
+
+        document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
     </script>
 
 
     </main>
+
+    <!-- Image lightbox (click a thumbnail to enlarge) -->
+    <div id="image-lightbox" class="hidden fixed inset-0 z-50 bg-black/80 items-center justify-center p-4 cursor-zoom-out" onclick="closeLightbox()">
+        <img src="" alt="attached image" class="max-w-full max-h-full rounded shadow-2xl" onclick="event.stopPropagation()" />
+        <button onclick="closeLightbox()" class="absolute top-4 right-4 text-white/90 hover:text-white text-3xl leading-none" aria-label="Close">&times;</button>
+    </div>
+
     <footer class="w-full text-center py-4 bg-gray-50 border-t border-gray-200 mt-8">
         <a href="https://pypi.org/project/simpleaudit/" target="_blank" rel="noopener noreferrer" class="text-indigo-600 hover:underline">simpleaudit on PyPI</a>
     </footer>

--- a/simpleaudit/visualization/server.py
+++ b/simpleaudit/visualization/server.py
@@ -301,6 +301,26 @@ def get_json_file(file_path: str):
     return JSONResponse(content=data)
 
 
+@app.get("/api/image", dependencies=[Depends(check_secret)])
+def get_image(uri: str):
+    # Reuse the audit's own loader so local paths, http(s), s3 & friends all
+    # resolve the same way they did at audit time, and non-images are rejected
+    # identically. Returns a data URI (not raw bytes) so the frontend can fetch
+    # it through apiFetch (carrying X-Secret) and assign it to an <img> src.
+    from ..utils import image_data_uri
+
+    try:
+        data_uri = image_data_uri(uri)
+    except ValueError:
+        raise HTTPException(status_code=415, detail="Not a previewable image")
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Image not found")
+    except OSError:
+        raise HTTPException(status_code=500, detail="Error reading image")
+
+    return JSONResponse(content={"data_uri": data_uri})
+
+
 def start_server(results_dir: str, host: str = "127.0.0.1", port: int = 8000):
     """
     Start the FastAPI server.

--- a/simpleaudit/visualization/visualizer.html
+++ b/simpleaudit/visualization/visualizer.html
@@ -262,7 +262,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <span class="hidden sm:inline">SimpleAudit Visualizer</span>
+                    <span class="hidden sm:inline">SimpleAudit Visualizer 2</span>
                     <span class="sm:hidden">SimpleAudit</span>
                 </h1>
                 <p class="text-sm text-gray-500 mt-1 hidden sm:block" id="file-info">No file loaded</p>
@@ -386,8 +386,16 @@
         </div>
     </div>
 
+    <!-- Image lightbox (click a thumbnail to enlarge) -->
+    <div id="image-lightbox" class="hidden fixed inset-0 z-50 bg-black/80 items-center justify-center p-4 cursor-zoom-out" onclick="closeLightbox()">
+        <img src="" alt="attached image" class="max-w-full max-h-full rounded shadow-2xl" onclick="event.stopPropagation()" />
+        <button onclick="closeLightbox()" class="absolute top-4 right-4 text-white/90 hover:text-white text-3xl leading-none" aria-label="Close">&times;</button>
+    </div>
+
     <!-- Logic -->
     <script>
+        document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
+
         // State
         let allScenarios = [];
         let currentScenarios = [];
@@ -1165,6 +1173,14 @@
             const history = s.history || [];
             const judgeFeedback = s.reasoning || s.feedback || 'No feedback available.';
 
+            // Attached file(s) sent with the first prompt. The path lives on a
+            // conversation entry (usually turn 0); fall back to a scenario-level
+            // field. May be a single string or a list.
+            const fileUris = fileUrisFromHistory(history, s);
+            // In the standalone offline viewer there is no backend to load local
+            // files, so only remote URLs can be previewed there.
+            const standalone = (window.__customUpload || forceCustomUpload) === true;
+
             let html = `
                 <div class="max-w-4xl mx-auto space-y-6 pb-20">
                     <!-- Mobile Back Button -->
@@ -1188,6 +1204,17 @@
                             </div>
                         </div>
                         <p class="text-gray-600 leading-relaxed">${escapeHtml(desc)}</p>
+                        ${fileUris.length ? `
+                        <div class="mt-4 pt-4 border-t border-gray-100">
+                            <div class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Attached file${fileUris.length > 1 ? 's' : ''}</div>
+                            <div class="space-y-1">
+                                ${fileUris.map(u => `
+                                    <div class="flex items-center gap-2 text-xs text-gray-500">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+                                        <code class="font-mono text-gray-600 break-all" title="${escapeHtml(u)}">${escapeHtml(u)}</code>
+                                    </div>`).join('')}
+                            </div>
+                        </div>` : ''}
                     </div>
             `;
 
@@ -1218,6 +1245,8 @@
                     const role = (turn.role || 'unknown').toUpperCase();
                     const content = turn.content || '';
                     const isUser = role === 'USER' || role === 'HUMAN';
+                    const turnUris = turn.file_uri ? (Array.isArray(turn.file_uri) ? turn.file_uri : [turn.file_uri]) : [];
+                    const contentBlock = `<div class="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap font-mono text-xs bg-gray-50/50 p-2 rounded border border-gray-100">${escapeHtml(content)}</div>`;
 
                     html += `
                         <div class="p-6 ${isUser ? 'bg-white' : 'bg-gray-50'}">
@@ -1232,7 +1261,8 @@
                                         <h4 class="text-sm font-semibold text-gray-900">${escapeHtml(role)}</h4>
                                         <span class="text-xs text-gray-400">Turn ${idx + 1}</span>
                                     </div>
-                                    <div class="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap font-mono text-xs bg-gray-50/50 p-2 rounded border border-gray-100">${escapeHtml(content)}</div>
+                                    ${contentBlock}
+                                    ${turnUris.length ? `<div class="flex flex-wrap gap-3 mt-2">${turnUris.map(u => attachmentPreview(u, standalone)).join('')}</div>` : ''}
                                 </div>
                             </div>
                         </div>
@@ -1283,6 +1313,7 @@
             html += `</div>`;
 
             container.innerHTML = html;
+            populateFilePreviews();
         }
 
         function escapeHtml(unsafe) {
@@ -1292,6 +1323,112 @@
                 .replace(/>/g, "&gt;")
                 .replace(/"/g, "&quot;")
                 .replace(/'/g, "&#039;");
+        }
+
+        // --- attached-file preview helpers -------------------------------
+        function fileUrisFromHistory(history, s) {
+            const entry = (history || []).find(t => t && t.file_uri);
+            const raw = entry ? entry.file_uri : (s && s.file_uri);
+            if (!raw) return [];
+            return Array.isArray(raw) ? raw : [raw];
+        }
+
+        function isRemoteUri(uri) {
+            return /^https?:\/\//i.test(String(uri));
+        }
+
+        function isImageUri(uri) {
+            const path = String(uri).split('?')[0].split('#')[0];
+            return /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(path);
+        }
+
+        function fileBaseName(uri) {
+            const path = String(uri).split('?')[0].split('#')[0];
+            const parts = path.split('/');
+            return parts[parts.length - 1] || String(uri);
+        }
+
+        // A generic file card (icon + name) for non-images and previews that
+        // cannot be loaded (e.g. local paths in the offline viewer).
+        function fileIconBlock(uri, note) {
+            return `
+                <div class="flex items-center gap-2 p-2 rounded border border-gray-200 bg-white max-w-[16rem]">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg>
+                    <div class="min-w-0">
+                        <div class="text-xs font-mono text-gray-600 truncate" title="${escapeHtml(uri)}">${escapeHtml(fileBaseName(uri))}</div>
+                        ${note ? `<div class="text-[10px] text-gray-400">${escapeHtml(note)}</div>` : ''}
+                    </div>
+                </div>`;
+        }
+
+        function imagePreviewMarkup(uri, src) {
+            const srcAttr = src ? `src="${escapeHtml(src)}"` : `data-load-uri="${escapeHtml(uri)}"`;
+            return `
+                <div>
+                    <img ${srcAttr} data-orig-uri="${escapeHtml(uri)}" alt="attached image"
+                         onclick="openLightbox(this.src)" onerror="filePreviewError(this)"
+                         class="file-preview-img max-h-40 rounded border border-gray-200 cursor-pointer bg-white" />
+                    <div class="text-[10px] text-gray-400 font-mono truncate mt-1 max-w-[16rem]" title="${escapeHtml(uri)}">${escapeHtml(fileBaseName(uri))}</div>
+                </div>`;
+        }
+
+        // Decide the preview for one attachment: image thumbnail, or a file icon
+        // for non-images / un-previewable local files.
+        function attachmentPreview(uri, standalone) {
+            if (!isImageUri(uri)) {
+                return fileIconBlock(uri);
+            }
+            if (isRemoteUri(uri)) {
+                return imagePreviewMarkup(uri, uri);
+            }
+            if (standalone) {
+                return fileIconBlock(uri, 'Local image — preview unavailable offline');
+            }
+            // Server mode, local path: load bytes lazily via the backend.
+            return imagePreviewMarkup(uri, null);
+        }
+
+        // Load thumbnails that need the backend (local paths), fetching through
+        // apiFetch so the X-Secret auth header is carried.
+        async function populateFilePreviews() {
+            const imgs = document.querySelectorAll('img.file-preview-img[data-load-uri]');
+            for (const img of imgs) {
+                const uri = img.getAttribute('data-load-uri');
+                img.removeAttribute('data-load-uri');
+                try {
+                    const resp = await apiFetch('/api/image?uri=' + encodeURIComponent(uri));
+                    if (!resp.ok) throw new Error('image load failed');
+                    const data = await resp.json();
+                    img.src = data.data_uri;
+                } catch (e) {
+                    filePreviewError(img);
+                }
+            }
+        }
+
+        function filePreviewError(img) {
+            const uri = img.getAttribute('data-orig-uri') || '';
+            const wrap = img.closest('div');
+            if (wrap) wrap.outerHTML = fileIconBlock(uri, 'Preview unavailable');
+        }
+
+        function openLightbox(src) {
+            if (!src) return;
+            const ov = document.getElementById('image-lightbox');
+            if (!ov) return;
+            const img = ov.querySelector('img');
+            if (img) img.src = src;
+            ov.classList.remove('hidden');
+            ov.classList.add('flex');
+        }
+
+        function closeLightbox() {
+            const ov = document.getElementById('image-lightbox');
+            if (!ov) return;
+            ov.classList.add('hidden');
+            ov.classList.remove('flex');
+            const img = ov.querySelector('img');
+            if (img) img.src = '';
         }
 
         // Copy current URL to clipboard

--- a/simpleaudit/visualization/visualizer.html
+++ b/simpleaudit/visualization/visualizer.html
@@ -262,7 +262,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                             d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                    <span class="hidden sm:inline">SimpleAudit Visualizer 2</span>
+                    <span class="hidden sm:inline">SimpleAudit Visualizer</span>
                     <span class="sm:hidden">SimpleAudit</span>
                 </h1>
                 <p class="text-sm text-gray-500 mt-1 hidden sm:block" id="file-info">No file loaded</p>


### PR DESCRIPTION
This introduces quite a bit of repetition between visualizer.html and scenario_viewer.html.

The focus remains on image files for now, and I have only tested image files.

NB the static page cannot preview the files, but it can show the path and a placeholder.