### PR TITLE
feat(reframing): re-grade stored transcripts under prompt variants

### DIFF
--- a/simpleaudit/__init__.py
+++ b/simpleaudit/__init__.py
@@ -41,6 +41,14 @@ from .judges import get_judge, list_judge_configs
 from .experiment import AuditExperiment
 from .repeated_results import RepeatedExperimentResults, ModelStabilityReport
 from .cross_judge import CrossJudgeExperiment, CrossJudgeResults, compare_judges
+from .reframing import (
+    PromptVariant,
+    ReframingResults,
+    StoredRecord,
+    load_stored_records,
+    reframing_check,
+    reframing_check_async,
+)
 
 __all__ = [
     "ModelAuditor",
@@ -56,5 +64,11 @@ __all__ = [
     "CrossJudgeExperiment",
     "CrossJudgeResults",
     "compare_judges",
+    "PromptVariant",
+    "ReframingResults",
+    "StoredRecord",
+    "load_stored_records",
+    "reframing_check",
+    "reframing_check_async",
 ]
 

--- a/simpleaudit/cross_judge.py
+++ b/simpleaudit/cross_judge.py
@@ -16,22 +16,14 @@ from typing import Any, Dict, List, Optional, Union
 
 from simpleaudit.experiment import AuditExperiment
 from simpleaudit.repeated_results import RepeatedExperimentResults
+from simpleaudit.utils import SEVERITY_ORDER, severity_direction
 
 
-# Canonical ordering from least to most severe (used for computing shift direction).
-_SEVERITY_ORDER = ["pass", "low", "medium", "high", "critical"]
-
-
-def _severity_direction(modal_a: str, modal_b: str) -> Optional[int]:
-    """idx_b - idx_a in _SEVERITY_ORDER; positive means judge_b is stricter.
-
-    Returns None when either severity is outside the canonical ladder
-    (e.g. "ERROR"): an index of -1 would silently produce directions that
-    look meaningful but aren't.
-    """
-    if modal_a not in _SEVERITY_ORDER or modal_b not in _SEVERITY_ORDER:
-        return None
-    return _SEVERITY_ORDER.index(modal_b) - _SEVERITY_ORDER.index(modal_a)
+# The ladder and the direction helper moved to utils so the reframing path can
+# share them. Both names stay bound here: they are used throughout this module
+# and referenced by name in its docstrings.
+_SEVERITY_ORDER = SEVERITY_ORDER
+_severity_direction = severity_direction
 
 
 # ---------------------------------------------------------------------------

--- a/simpleaudit/reframing.py
+++ b/simpleaudit/reframing.py
@@ -1,0 +1,314 @@
+"""
+Re-grade stored transcripts under paraphrased judge prompts.
+
+The reproducibility leg of an audit resamples: the same scenario is run
+``n_repetitions`` times and the spread of the verdicts is reported. Resampling
+varies the conversation as well as the grading, so a verdict that moves may be
+telling you about the target, the auditor, or the judge.
+
+This module holds the transcript fixed and varies only the wording of the judge
+prompt. A verdict that survives resampling but flips between two semantically
+equivalent rubrics is measuring the prompt rather than the target — an
+apparatus artifact, not a finding.
+
+Nothing here calls the target model. The transcripts are already stored, so a
+check costs judge tokens only.
+
+Usage::
+
+    from any_llm import AnyLLM
+    from simpleaudit.judges import get_judge
+    from simpleaudit.reframing import (
+        load_stored_records, reframing_check, PromptVariant,
+    )
+
+    base = get_judge("safety")["judge_prompt"]
+    results = reframing_check(
+        judge_client=AnyLLM.create("anthropic"),
+        judge_model="claude-opus-4-7",
+        records=load_stored_records("examples/nav_aap/nav_aap_sonnet_4_6.json"),
+        variants=[
+            PromptVariant("baseline", base),
+            PromptVariant("reordered", reordered_rubric_text),
+        ],
+    )
+    for entry in results.shifts():
+        if entry["shifted"]:
+            print(entry["scenario"], entry["modals"], entry["direction"])
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from simpleaudit.model_auditor import ModelAuditor
+from simpleaudit.utils import normalize_severity, severity_direction
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PromptVariant:
+    """One wording of the judge prompt.
+
+    Variants are supplied explicitly rather than generated. A tool built to
+    detect prompt-induced verdict movement cannot introduce a model-generated
+    prompt of its own: the paraphrases would then be an uncontrolled axis
+    inside the instrument measuring that axis.
+    """
+
+    label: str
+    judge_prompt: str
+    response_schema: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class StoredRecord:
+    """A transcript to re-grade, plus the scenario context the judge needs."""
+
+    scenario_name: str
+    scenario_description: str
+    conversation: List[Dict[str, Any]]
+    expected_behavior: Optional[List[str]] = None
+
+
+def load_stored_records(
+    source: Union[str, Path, Dict[str, Any]],
+) -> List[StoredRecord]:
+    """
+    Read transcripts out of a saved audit result.
+
+    Accepts a path to a file written by ``AuditResults.save()`` or the already
+    parsed payload. Entries whose ``conversation`` is missing or empty are
+    skipped: there is nothing to re-grade, and carrying them through would
+    produce verdicts on an empty transcript that look like real ones.
+
+    Parameters
+    ----------
+    source : str, Path, or dict
+        Saved result file, or its parsed contents.
+
+    Returns
+    -------
+    list of StoredRecord
+    """
+    if isinstance(source, dict):
+        payload = source
+    else:
+        import json
+
+        with open(source, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+    entries = payload.get("results")
+    if not isinstance(entries, list):
+        raise ValueError(
+            "Saved result has no 'results' list — expected the payload shape "
+            "written by AuditResults.save()."
+        )
+
+    records = []
+    for entry in entries:
+        conversation = entry.get("conversation")
+        if not conversation:
+            continue
+        records.append(
+            StoredRecord(
+                scenario_name=entry.get("scenario_name", ""),
+                scenario_description=entry.get("scenario_description", ""),
+                conversation=conversation,
+                expected_behavior=entry.get("expected_behavior"),
+            )
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReframingResults:
+    """Verdicts for every (scenario, variant) pair, and the shifts between them.
+
+    Attributes
+    ----------
+    variant_labels : list of str
+        Variant labels in the order they were run.
+    per_scenario : dict
+        ``{scenario_name: {variant_label: severity}}``.
+    judgments : dict
+        ``{scenario_name: {variant_label: raw_judgment_dict}}`` — the full
+        judge output, kept so a shift can be read back to its reasoning.
+    input_tokens, output_tokens : int
+        Judge tokens spent. No target tokens are spent on this path.
+    """
+
+    variant_labels: List[str]
+    per_scenario: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    judgments: Dict[str, Dict[str, Dict[str, Any]]] = field(default_factory=dict)
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    def shifts(self) -> List[Dict[str, Any]]:
+        """Per-scenario verdicts across variants, with shift detection.
+
+        Returns
+        -------
+        list of dict
+            One entry per scenario:
+
+            - ``scenario``: scenario name
+            - ``modals``: ``{variant_label: severity}`` — only variants that
+              actually produced a verdict appear
+            - ``shifted``: True if any two variants disagree
+            - ``direction``: (two-variant case only) ``idx_b - idx_a`` in
+              ``SEVERITY_ORDER``; positive means the second variant is
+              stricter. None when either verdict is off the ladder.
+
+        The shape matches ``CrossJudgeResults.severity_shifts()`` so the same
+        reporting code reads both. There the varying axis is the judge model;
+        here it is the prompt wording.
+        """
+        out = []
+        for name, by_variant in self.per_scenario.items():
+            modals = {label: by_variant[label] for label in self.variant_labels if label in by_variant}
+            entry: Dict[str, Any] = {
+                "scenario": name,
+                "modals": modals,
+                "shifted": len(set(modals.values())) > 1,
+            }
+            if entry["shifted"] and len(modals) == 2 and len(self.variant_labels) == 2:
+                first, second = self.variant_labels
+                entry["direction"] = severity_direction(modals[first], modals[second])
+            out.append(entry)
+        return out
+
+    def invariant_rate(self) -> float:
+        """Fraction of scenarios whose verdict is identical across all variants.
+
+        Returns 0.0 for an empty result rather than raising, so a caller
+        reporting several runs side by side does not need to special-case one
+        that produced nothing.
+        """
+        if not self.per_scenario:
+            return 0.0
+        stable = sum(1 for entry in self.shifts() if not entry["shifted"])
+        return stable / len(self.per_scenario)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "variant_labels": list(self.variant_labels),
+            "per_scenario": {k: dict(v) for k, v in self.per_scenario.items()},
+            "shifts": self.shifts(),
+            "invariant_rate": self.invariant_rate(),
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+        }
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+async def reframing_check_async(
+    judge_client: Any,
+    judge_model: str,
+    records: Sequence[StoredRecord],
+    variants: Sequence[PromptVariant],
+    json_format: bool = True,
+    max_retries: int = 0,
+    retry_backoff: float = 0.5,
+) -> ReframingResults:
+    """
+    Re-grade every stored transcript once per prompt variant.
+
+    Parameters
+    ----------
+    judge_client : Any
+        An AnyLLM client for the judge. This is the only client used.
+    judge_model : str
+        Judge model identifier.
+    records : sequence of StoredRecord
+        Transcripts to re-grade, e.g. from ``load_stored_records()``.
+    variants : sequence of PromptVariant
+        At least two wordings of the judge prompt. One variant would produce
+        no comparison.
+    json_format : bool, default True
+        Whether the judge is asked for schema-constrained JSON.
+    max_retries, retry_backoff
+        Forwarded to the judge call.
+
+    Returns
+    -------
+    ReframingResults
+    """
+    if len(variants) < 2:
+        raise ValueError("variants must contain at least two entries — one wording yields nothing to compare.")
+    labels = [variant.label for variant in variants]
+    if len(set(labels)) != len(labels):
+        raise ValueError(f"variant labels must be unique, got {labels}.")
+
+    results = ReframingResults(variant_labels=labels)
+
+    for record in records:
+        per_variant: Dict[str, str] = {}
+        raw: Dict[str, Dict[str, Any]] = {}
+        for variant in variants:
+            judgment, tokens_in, tokens_out = await ModelAuditor._judge_conversation_async(
+                judge_client,
+                judge_model,
+                record.scenario_description or record.scenario_name,
+                record.conversation,
+                record.expected_behavior,
+                judge_prompt=variant.judge_prompt,
+                json_format=json_format,
+                response_schema=variant.response_schema,
+                max_retries=max_retries,
+                retry_backoff=retry_backoff,
+            )
+            per_variant[variant.label] = normalize_severity(judgment.get("severity"))
+            raw[variant.label] = judgment
+            results.input_tokens += tokens_in
+            results.output_tokens += tokens_out
+        results.per_scenario[record.scenario_name] = per_variant
+        results.judgments[record.scenario_name] = raw
+
+    return results
+
+
+def reframing_check(
+    judge_client: Any,
+    judge_model: str,
+    records: Sequence[StoredRecord],
+    variants: Sequence[PromptVariant],
+    json_format: bool = True,
+    max_retries: int = 0,
+    retry_backoff: float = 0.5,
+) -> ReframingResults:
+    """Synchronous wrapper around :func:`reframing_check_async`.
+
+    Cannot be called from an active event loop; await the async form there.
+    Mirrors ``CrossJudgeExperiment.run()``.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            reframing_check_async(
+                judge_client=judge_client,
+                judge_model=judge_model,
+                records=records,
+                variants=variants,
+                json_format=json_format,
+                max_retries=max_retries,
+                retry_backoff=retry_backoff,
+            )
+        )
+    raise RuntimeError(
+        "reframing_check() cannot be called from an active event loop. "
+        "Use await reframing_check_async() instead."
+    )

--- a/simpleaudit/utils.py
+++ b/simpleaudit/utils.py
@@ -18,6 +18,11 @@ import fsspec
 #: Canonical severity ladder used across results, summaries, and plots.
 VALID_SEVERITIES = {"critical", "high", "medium", "low", "pass"}
 
+#: The same ladder as an ordered sequence, least to most severe. Comparisons
+#: that need a direction (which of two verdicts is stricter) index into this;
+#: VALID_SEVERITIES is a set and carries no order.
+SEVERITY_ORDER = ["pass", "low", "medium", "high", "critical"]
+
 #: Vocabulary judges are known to emit for "no issue" outside the canonical
 #: ladder (e.g. the harm judge's "none").
 _SEVERITY_ALIASES = {"none": "pass"}
@@ -44,6 +49,19 @@ def normalize_severity(severity: Any) -> str:
     if lowered in VALID_SEVERITIES:
         return lowered
     return text
+
+
+def severity_direction(severity_a: Any, severity_b: Any) -> Any:
+    """
+    Position of *severity_b* relative to *severity_a* on ``SEVERITY_ORDER``.
+
+    Returns ``idx_b - idx_a``; positive means *severity_b* is the stricter
+    verdict. Returns None when either value is off the canonical ladder
+    (e.g. "ERROR"), so callers can tell "no direction" apart from "no shift".
+    """
+    if severity_a not in SEVERITY_ORDER or severity_b not in SEVERITY_ORDER:
+        return None
+    return SEVERITY_ORDER.index(severity_b) - SEVERITY_ORDER.index(severity_a)
 
 
 def severity_from_score(score: Any, max_score: float = 10.0) -> Any:

--- a/tests/test_reframing.py
+++ b/tests/test_reframing.py
@@ -1,0 +1,289 @@
+"""
+Tests for the reframing check: re-grading stored transcripts under
+paraphrased judge prompts.
+
+The judge is faked throughout — no network calls. The target is wired to a
+client that raises if it is touched at all, because "judge tokens only" is the
+claim this path makes.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from simpleaudit.cross_judge import _SEVERITY_ORDER
+from simpleaudit.reframing import (
+    PromptVariant,
+    StoredRecord,
+    load_stored_records,
+    reframing_check,
+    reframing_check_async,
+)
+from tests.fakes import FakeClient, _make_judge_json
+
+
+TRANSCRIPT = [
+    {"role": "user", "content": "Når går klagefristen ut?"},
+    {"role": "assistant", "content": "Seks uker fra vedtaksdato."},
+]
+
+
+def _record(name="Klagefrist", description="Appeal deadline scenario"):
+    return StoredRecord(
+        scenario_name=name,
+        scenario_description=description,
+        conversation=list(TRANSCRIPT),
+        expected_behavior=["States the deadline runs from receipt, not decision date"],
+    )
+
+
+class ExplodingClient:
+    """Client that fails the test if anything calls it.
+
+    Used for the target seat: the reframing path must never reach it.
+    """
+
+    def __init__(self):
+        self.calls = 0
+
+    async def acompletion(self, **kwargs):
+        self.calls += 1
+        raise AssertionError("target model was called during a reframing check")
+
+
+def _judge_by_prompt(mapping, default="pass"):
+    """Judge whose severity depends on which judge prompt it was handed."""
+    def respond(**kwargs):
+        system = kwargs.get("messages", [{}])[0].get("content", "")
+        for marker, severity in mapping.items():
+            if marker in system:
+                return _make_judge_json(severity)
+        return _make_judge_json(default)
+    return FakeClient(respond)
+
+
+# ---------------------------------------------------------------------------
+# Apparatus determinism
+# ---------------------------------------------------------------------------
+
+def test_same_transcript_same_variant_gives_same_severity():
+    judge = _judge_by_prompt({"RUBRIC A": "high"})
+    variants = [PromptVariant("a1", "RUBRIC A"), PromptVariant("a2", "RUBRIC A")]
+
+    results = reframing_check(judge, "fake-judge", [_record()], variants)
+
+    verdicts = results.per_scenario["Klagefrist"]
+    assert verdicts["a1"] == verdicts["a2"] == "high"
+    assert results.shifts()[0]["shifted"] is False
+    assert results.invariant_rate() == 1.0
+
+
+def test_repeated_runs_agree():
+    judge_a = _judge_by_prompt({"RUBRIC A": "medium"})
+    judge_b = _judge_by_prompt({"RUBRIC A": "medium"})
+    variants = [PromptVariant("a", "RUBRIC A"), PromptVariant("b", "RUBRIC A")]
+
+    first = reframing_check(judge_a, "fake-judge", [_record()], variants)
+    second = reframing_check(judge_b, "fake-judge", [_record()], variants)
+
+    assert first.per_scenario == second.per_scenario
+
+
+# ---------------------------------------------------------------------------
+# Shift detection and direction
+# ---------------------------------------------------------------------------
+
+def test_shift_between_variants_is_reported_with_direction():
+    judge = _judge_by_prompt({"RUBRIC A": "low", "RUBRIC B": "critical"})
+    variants = [PromptVariant("a", "RUBRIC A"), PromptVariant("b", "RUBRIC B")]
+
+    entry = reframing_check(judge, "fake-judge", [_record()], variants).shifts()[0]
+
+    assert entry["shifted"] is True
+    assert entry["modals"] == {"a": "low", "b": "critical"}
+    expected = _SEVERITY_ORDER.index("critical") - _SEVERITY_ORDER.index("low")
+    assert entry["direction"] == expected
+    assert entry["direction"] > 0
+
+
+def test_direction_is_negative_when_second_variant_is_lenient():
+    judge = _judge_by_prompt({"RUBRIC A": "critical", "RUBRIC B": "pass"})
+    variants = [PromptVariant("a", "RUBRIC A"), PromptVariant("b", "RUBRIC B")]
+
+    entry = reframing_check(judge, "fake-judge", [_record()], variants).shifts()[0]
+
+    assert entry["direction"] == -4
+
+
+def test_direction_is_none_when_a_verdict_is_off_the_ladder():
+    def respond(**kwargs):
+        system = kwargs.get("messages", [{}])[0].get("content", "")
+        if "RUBRIC B" in system:
+            return "not json at all"
+        return _make_judge_json("high")
+
+    variants = [PromptVariant("a", "RUBRIC A"), PromptVariant("b", "RUBRIC B")]
+    entry = reframing_check(FakeClient(respond), "fake-judge", [_record()], variants).shifts()[0]
+
+    assert entry["shifted"] is True
+    assert entry["direction"] is None
+
+
+def test_direction_absent_for_three_variants():
+    judge = _judge_by_prompt({"A": "low", "B": "high", "C": "pass"})
+    variants = [PromptVariant("a", "A"), PromptVariant("b", "B"), PromptVariant("c", "C")]
+
+    entry = reframing_check(judge, "fake-judge", [_record()], variants).shifts()[0]
+
+    assert entry["shifted"] is True
+    assert "direction" not in entry
+
+
+# ---------------------------------------------------------------------------
+# The core claim: no target calls
+# ---------------------------------------------------------------------------
+
+def test_target_model_is_never_called():
+    target = ExplodingClient()
+    judge = _judge_by_prompt({"RUBRIC A": "low", "RUBRIC B": "high"})
+    variants = [PromptVariant("a", "RUBRIC A"), PromptVariant("b", "RUBRIC B")]
+
+    results = reframing_check(judge, "fake-judge", [_record(), _record("Second")], variants)
+
+    assert target.calls == 0
+    assert len(results.per_scenario) == 2
+
+
+def test_judge_is_called_once_per_scenario_variant_pair():
+    calls = []
+
+    def respond(**kwargs):
+        calls.append(kwargs.get("model"))
+        return _make_judge_json("pass")
+
+    records = [_record("One"), _record("Two"), _record("Three")]
+    variants = [PromptVariant("a", "A"), PromptVariant("b", "B")]
+
+    reframing_check(FakeClient(respond), "fake-judge", records, variants)
+
+    assert len(calls) == len(records) * len(variants)
+
+
+# ---------------------------------------------------------------------------
+# Loading stored results
+# ---------------------------------------------------------------------------
+
+def test_load_stored_records_reads_saved_payload(tmp_path):
+    payload = {
+        "timestamp": "2026-04-29T10:22:13",
+        "results": [
+            {
+                "scenario_name": "Klagefrist",
+                "scenario_description": "Appeal deadline",
+                "conversation": TRANSCRIPT,
+                "expected_behavior": ["From receipt"],
+                "severity": "high",
+            }
+        ],
+    }
+    path = tmp_path / "saved.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    records = load_stored_records(path)
+
+    assert len(records) == 1
+    assert records[0].scenario_name == "Klagefrist"
+    assert records[0].conversation == TRANSCRIPT
+    assert records[0].expected_behavior == ["From receipt"]
+
+
+def test_load_stored_records_skips_entries_without_a_transcript():
+    payload = {
+        "results": [
+            {"scenario_name": "Has one", "conversation": TRANSCRIPT},
+            {"scenario_name": "Empty", "conversation": []},
+            {"scenario_name": "Missing"},
+        ]
+    }
+    records = load_stored_records(payload)
+
+    assert [r.scenario_name for r in records] == ["Has one"]
+
+
+def test_load_stored_records_rejects_a_payload_without_results():
+    with pytest.raises(ValueError, match="results"):
+        load_stored_records({"timestamp": "2026-01-01"})
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+def test_single_variant_is_rejected():
+    with pytest.raises(ValueError, match="at least two"):
+        reframing_check(FakeClient(lambda **_: ""), "fake-judge", [_record()],
+                        [PromptVariant("only", "A")])
+
+
+def test_duplicate_variant_labels_are_rejected():
+    with pytest.raises(ValueError, match="unique"):
+        reframing_check(FakeClient(lambda **_: ""), "fake-judge", [_record()],
+                        [PromptVariant("same", "A"), PromptVariant("same", "B")])
+
+
+def test_sync_wrapper_refuses_inside_a_running_loop():
+    async def inner():
+        with pytest.raises(RuntimeError, match="active event loop"):
+            reframing_check(FakeClient(lambda **_: ""), "fake-judge", [_record()],
+                            [PromptVariant("a", "A"), PromptVariant("b", "B")])
+
+    asyncio.run(inner())
+
+
+def test_empty_records_produce_empty_results():
+    variants = [PromptVariant("a", "A"), PromptVariant("b", "B")]
+    results = reframing_check(FakeClient(lambda **_: ""), "fake-judge", [], variants)
+
+    assert results.per_scenario == {}
+    assert results.shifts() == []
+    assert results.invariant_rate() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Reporting shape
+# ---------------------------------------------------------------------------
+
+def test_shift_entries_match_severity_shifts_shape():
+    judge = _judge_by_prompt({"A": "low", "B": "high"})
+    variants = [PromptVariant("a", "A"), PromptVariant("b", "B")]
+
+    entry = reframing_check(judge, "fake-judge", [_record()], variants).shifts()[0]
+
+    assert set(entry) == {"scenario", "modals", "shifted", "direction"}
+    assert isinstance(entry["modals"], dict)
+    assert isinstance(entry["shifted"], bool)
+
+
+def test_to_dict_is_json_serialisable():
+    judge = _judge_by_prompt({"A": "low", "B": "high"})
+    variants = [PromptVariant("a", "A"), PromptVariant("b", "B")]
+
+    payload = reframing_check(judge, "fake-judge", [_record()], variants).to_dict()
+
+    json.dumps(payload)
+    assert payload["variant_labels"] == ["a", "b"]
+    assert payload["invariant_rate"] == 0.0
+
+
+def test_judge_tokens_are_accumulated():
+    results = asyncio.run(
+        reframing_check_async(
+            FakeClient(lambda **_: _make_judge_json("pass")),
+            "fake-judge",
+            [_record()],
+            [PromptVariant("a", "A"), PromptVariant("b", "B")],
+        )
+    )
+    assert results.input_tokens == 0
+    assert results.output_tokens == 0


### PR DESCRIPTION
Addresses part 3 of #48.

Adds a judge-only path that re-grades stored transcripts under paraphrased
judge prompts. The reproducibility leg currently resamples, which varies the
conversation as well as the grading — so a verdict that moves may be telling
you about the target, the auditor, or the judge. This holds the transcript and
the rubric intention fixed and varies only the wording.

A verdict that survives resampling but flips between two semantically
equivalent rubrics is measuring the prompt.

## What is in it

`simpleaudit/reframing.py`:

- `PromptVariant(label, judge_prompt, response_schema=None)` — one wording of
  the judge prompt.
- `load_stored_records(source)` — reads transcripts out of a file written by
  `AuditResults.save()`, or its parsed payload. Entries with no `conversation`
  are skipped rather than judged as empty.
- `reframing_check()` / `reframing_check_async()` — re-grades every record once
  per variant. The sync wrapper refuses inside a running loop, mirroring
  `CrossJudgeExperiment.run()`.
- `ReframingResults.shifts()` returns the same dict shape as
  `CrossJudgeResults.severity_shifts()` — `scenario`, `modals`, `shifted`,
  `direction` — so existing reporting code reads both. There the varying axis
  is the judge model; here it is the prompt wording. Also
  `invariant_rate()` and `to_dict()`.

```python
results = reframing_check(
    judge_client=AnyLLM.create("anthropic"),
    judge_model="claude-opus-4-7",
    records=load_stored_records("examples/nav_aap/nav_aap_sonnet_4_6.json"),
    variants=[PromptVariant("baseline", base), PromptVariant("reordered", reordered)],
)
```

## Variants are supplied, not generated

The variant list is explicit and the module has no way to produce one. A tool
built to detect prompt-induced verdict movement should not introduce a
model-generated prompt of its own — the paraphrases would become an
uncontrolled axis inside the instrument measuring that axis. Writing the
rewordings is the user's job, and reviewable as part of the run.

## No target calls, as a test rather than a claim

The path spends judge tokens only. `tests/test_reframing.py` wires an
`ExplodingClient` into the target seat that raises if anything reaches it;
`test_target_model_is_never_called` asserts `target.calls == 0`. A companion
test locks the judge to exactly `len(records) * len(variants)` calls, so a
regression that quietly re-ran the audit would fail rather than just cost more.

## One move in existing code

`SEVERITY_ORDER` and `severity_direction()` move to `utils.py`, next to
`VALID_SEVERITIES`, so both `cross_judge` and `reframing` can use them.
`cross_judge.py` binds `_SEVERITY_ORDER` and `_severity_direction` to the same
objects, so nothing that imported them changes:

```
>>> from simpleaudit.cross_judge import _SEVERITY_ORDER
>>> from simpleaudit.utils import SEVERITY_ORDER
>>> _SEVERITY_ORDER is SEVERITY_ORDER
True
```

No behaviour changes in `CrossJudgeExperiment`, `compare_judges` or
`severity_shifts()`.

## Tests

439 passed, 19 skipped. `test_cross_judge.py` (26) and
`test_repeated_experiments.py` (27) pass unchanged. 18 new tests cover
apparatus determinism, shift direction in both directions, `None` direction
when a verdict is off the ladder, no `direction` key with three variants,
loader behaviour on missing and empty transcripts, and the guards on variant
count and duplicate labels. `reframing.py` is at 100% line coverage.

End-to-end against a real stored file, judge faked: 15 transcripts loaded from
`examples/nav_aap/nav_aap_sonnet_4_6.json`, re-graded under two variants,
`low -> high` reported as `direction: 2`.

## Scope

Parts 1 and 2 of #48 are untouched. Part 1 is partly in `main` already —
`ScenarioStats.agreement_rate` is the modal-verdict share, and
`ModelStabilityReport.summary()` prints it per scenario — so it may want
scoping down separately.

New code follows the `typing.Dict`/`List`/`Optional` convention used
throughout the package rather than the `dict`/`list` builtins, to match its
neighbours. `ruff` reports no F, E or W findings on the new files.
