### PR TITLE
Unpack the judge tuple in the rejudge example scripts

### DIFF
--- a/examples/helsedir_sexhealth_no/rejudge_abstention_experiment.py
+++ b/examples/helsedir_sexhealth_no/rejudge_abstention_experiment.py
@@ -96,7 +96,7 @@ async def _judge_one_with_retry(judge_client, cfg, scenario, conversation, max_a
     last_exc = None
     for attempt in range(max_attempts):
         try:
-            return await ModelAuditor._judge_conversation_async(
+            judgment, _, _ = await ModelAuditor._judge_conversation_async(
                 client=judge_client,
                 model=JUDGE_MODEL,
                 scenario=scenario["description"],
@@ -106,6 +106,7 @@ async def _judge_one_with_retry(judge_client, cfg, scenario, conversation, max_a
                 json_format=True,
                 response_schema=cfg.get("response_schema"),
             )
+            return judgment
         except Exception as exc:
             last_exc = exc
             if attempt < max_attempts - 1:

--- a/examples/helsedir_sexhealth_no/rejudge_stored_conversations.py
+++ b/examples/helsedir_sexhealth_no/rejudge_stored_conversations.py
@@ -100,7 +100,7 @@ async def judge_all(judge_name: str, out_filename: str) -> Path:
         conversation = entry["conversation"]
         scenario = scenarios_by_name[name]
 
-        judgment = await ModelAuditor._judge_conversation_async(
+        judgment, _, _ = await ModelAuditor._judge_conversation_async(
             client=judge_client,
             model=JUDGE_MODEL,
             scenario=scenario["description"],


### PR DESCRIPTION
`ModelAuditor._judge_conversation_async` returns
`(judgment, input_tokens, output_tokens)`. Both re-judge scripts under
`examples/helsedir_sexhealth_no/` date from 2026-05-14, before the token
counts were added, and still bind the whole tuple as the judgment.

`rejudge_stored_conversations.py` crashes:

```
AttributeError: 'tuple' object has no attribute 'get'
```

at `judgment.get("severity", "ERROR")` on the first scenario.

`rejudge_abstention_experiment.py` does not crash. Its retry wrapper returns
the tuple, `judge_all` stores it under `"judgment"`, and `json.dump` writes it
as a three-element array:

```json
{"judgment": [{"severity": "high", "issues_found": []}, 1234, 56]}
```

so the output file looks complete while the judgment field is the wrong shape.

Both are one unpack. The retry wrapper keeps its behaviour: the call stays
inside the `try`, so a transient error is still caught and retried.

`extract_conversations.py` in the same directory does not call the judge and
is unaffected.
