### PR TITLE
fix: match the fallback version literal to pyproject

### DIFF
--- a/simpleaudit/__init__.py
+++ b/simpleaudit/__init__.py
@@ -31,7 +31,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("simpleaudit")
 except PackageNotFoundError:  # running from a source checkout without install
-    __version__ = "0.1.9"
+    __version__ = "0.1.10"
 __author__ = "SimpleAudit Contributors"
 
 from .model_auditor import ModelAuditor


### PR DESCRIPTION
One line: the fallback version literal in `simpleaudit/__init__.py` is 0.1.9
while `pyproject.toml` is 0.1.10.

## What's wrong

`__version__` is resolved from installed metadata first, and only falls back to
the literal when that lookup raises:

```python
try:
    __version__ = version("simpleaudit")
except PackageNotFoundError:  # running from a source checkout without install
    __version__ = "0.1.9"
```

A pip-installed `simpleaudit==0.1.10` reports 0.1.10 correctly, since metadata
answers first, and the bug never surfaces there. What's wrong is the tree. The
commit tagged `v0.1.10` carries a literal that says 0.1.9, so importing the
package from a source checkout without installing it gives a version string one
release behind the code being run. That covers a clone on `PYTHONPATH`, a CI job
that runs tests against the working tree, and anything that logs
`simpleaudit.__version__` from a checkout.

`test_fallback_version_literal_matches_pyproject` exists to catch this, and fails
on `dev` and `main` from 8a781f3 onward: the bump moved `pyproject.toml` and left
the literal alone.

It has happened before. The `0.1.9` tag has the literal at 0.1.8, so the bump has
missed the literal on two consecutive releases. This PR closes the 0.1.10
instance; reading the target from `pyproject.toml` at bump time, or a release step
that fails on the mismatch, would stop it recurring.

## The change

```diff
 except PackageNotFoundError:  # running from a source checkout without install
-    __version__ = "0.1.9"
+    __version__ = "0.1.10"
```

One line, one file. `pyproject.toml` is not touched, no other code is touched,
nothing is reformatted.

## Verification

Python 3.12, on `dev`:

```
before   491 collected   471 passed, 19 skipped, 1 failed
after    491 collected   472 passed, 19 skipped
```

The only test that changes status is
`test_fallback_version_literal_matches_pyproject`, FAILED → PASSED. Diffing the
full per-test outcome list before and after shows no other movement.

Based on `dev` rather than `main` so it travels with the next dev→main sync, the
direction #55 used. It applies cleanly to `main` if you'd rather take it there for
the next release.

My fragility PR for #48 is blocked behind this one, since it can't show a green
tick while this test is red, but the two changes are independent and this one
stands on its own.
