### PR TITLE
feat(stability): per-scenario fragility signal over stored runs

### DIFF
--- a/simpleaudit/__init__.py
+++ b/simpleaudit/__init__.py
@@ -39,7 +39,12 @@ from .results import AuditResults, AuditResult
 from .scenarios import get_scenarios, list_scenario_packs
 from .judges import get_judge, list_judge_configs
 from .experiment import AuditExperiment
-from .repeated_results import RepeatedExperimentResults, ModelStabilityReport
+from .repeated_results import (
+    FRAGILE_THRESHOLD_DEFAULT,
+    ModelStabilityReport,
+    RepeatedExperimentResults,
+    ScenarioStats,
+)
 from .cross_judge import CrossJudgeExperiment, CrossJudgeResults, compare_judges
 from .reframing import (
     PromptVariant,
@@ -61,6 +66,8 @@ __all__ = [
     "AuditExperiment",
     "RepeatedExperimentResults",
     "ModelStabilityReport",
+    "ScenarioStats",
+    "FRAGILE_THRESHOLD_DEFAULT",
     "CrossJudgeExperiment",
     "CrossJudgeResults",
     "compare_judges",

--- a/simpleaudit/repeated_results.py
+++ b/simpleaudit/repeated_results.py
@@ -3,9 +3,32 @@ Repeated-run results for SimpleAudit.
 
 Holds results from running an AuditExperiment multiple times and provides
 stability statistics across runs.
+
+Stability is reported at two levels. The aggregate level — mean, std and CV
+over whole-run scores — answers whether a model's overall score has settled.
+The per-scenario level answers which individual verdicts have settled, and
+that is a different question: a scenario swinging between pass and critical
+can sit inside a perfectly steady mean, and a single-run "critical" on it
+should not be read the same way as one on a scenario that never moves.
+
+The per-scenario statistics here — modal share, normalised entropy and
+ordinal spread — are the reproducibility leg of the validity chain pushed
+down to the scenario. They cost nothing to compute: the verdicts were
+already produced by the runs the experiment paid for. The choice to derive
+fragility from existing disagreement rather than from new perturbation runs
+follows Zhao et al., *Jagged Judges: Epistemic Stability Under Silence,
+Pressure, and Persistence* (2026), https://arxiv.org/abs/2608.12645, which
+identifies baseline jury majority strength as the most effective single-shot
+signal for anticipating which items wiggle. Modal share is that quantity as
+it already exists here, so the disagreement across ``n_repetitions`` is a
+signal the runs have paid for whether or not anyone reads it.
+
+The complementary check, which varies the judge prompt rather than resampling
+it, lives in :mod:`simpleaudit.reframing`.
 """
 
 import json
+import math
 import statistics
 import warnings
 from collections import Counter
@@ -14,6 +37,86 @@ from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from simpleaudit.results import AuditResult, AuditResults, _atomic_json_dump
+from simpleaudit.utils import SEVERITY_ORDER
+
+
+#: Default modal-verdict share below which a scenario counts as fragile.
+#: Used by both ``ModelStabilityReport.fragile()`` and the flag in
+#: ``summary()``, so the printed report and the queryable accessor can never
+#: disagree about which scenarios are fragile.
+FRAGILE_THRESHOLD_DEFAULT = 0.6
+
+
+# ---------------------------------------------------------------------------
+# Fragility statistics over a scenario's severity verdicts
+# ---------------------------------------------------------------------------
+
+def _normalised_entropy(severities: List[str]) -> float:
+    """Shannon entropy of the severity distribution, scaled to 0.0–1.0.
+
+    0.0 means every run returned the same verdict. Higher means the runs
+    spread across more levels, more evenly.
+
+    The denominator is ``log(len(SEVERITY_ORDER))`` — the full canonical
+    ladder — and not the number of levels actually observed. Normalising
+    against the observed count would rescale every scenario to its own
+    maximum, so a scenario split evenly between two severities and one split
+    evenly between five would both read 1.0 despite being very different
+    kinds of unstable. The fixed denominator keeps the number comparable
+    across scenarios, at a cost worth stating plainly: 1.0 needs the verdicts
+    spread evenly over all five levels, which few run counts allow. Below five
+    runs the ceiling is ``log(n) / log(5)`` — a two-run scenario tops out at
+    0.43 even when its two verdicts disagree completely. At five or more it is
+    exactly 1.0 only when n is a multiple of five, and a little under otherwise
+    (0.97 at n=6), because n verdicts cannot be split evenly across five levels
+    unless five divides n. Read it as a position on a fixed scale, not as a
+    percentage of the disagreement that was achievable in this many runs.
+
+    Verdicts outside ``SEVERITY_ORDER`` (e.g. "ERROR", or a custom judge
+    vocabulary) are counted as their own levels rather than dropped, since
+    a run that errored is a run that did not agree. A distribution wider
+    than the canonical ladder is clamped to 1.0.
+    """
+    if not severities:
+        return 0.0
+    total = len(severities)
+    entropy = 0.0
+    for count in Counter(severities).values():
+        p = count / total
+        entropy -= p * math.log(p)
+    return min(entropy / math.log(len(SEVERITY_ORDER)), 1.0)
+
+
+def _ordinal_spread(severities: List[str]) -> Optional[float]:
+    """Population standard deviation of the verdicts on the 0–4 severity scale.
+
+    Severities are mapped to their index in ``SEVERITY_ORDER`` ("pass" = 0 …
+    "critical" = 4) and the spread of those indices is returned, so a scenario
+    flipping pass/critical scores higher than one flipping high/critical. The
+    maximum is 2.0, from an even split between the two ends of the ladder, so
+    it is only attainable when n is even; at odd n the ceiling is a little
+    lower (1.886 at n=3).
+
+    This is not a duplicate of ``ModelStabilityReport.std_score``. That is the
+    sample standard deviation of the whole-run *score* (0–100, one value per
+    run, across every scenario); this is the spread of one scenario's
+    *severity verdicts*. A model can hold a steady overall score while one
+    scenario swings between pass and critical, and only this number sees it.
+    The population form is used rather than the sample form because the N runs
+    are the whole set being described, not a sample drawn from a larger one.
+
+    Returns None when any verdict is off the canonical ladder, matching
+    ``severity_direction()``: an "ERROR" verdict has no position on a 0–4
+    scale, and returning 0.0 would report it as perfect agreement.
+    """
+    if not severities:
+        return 0.0
+    if any(s not in SEVERITY_ORDER for s in severities):
+        return None
+    indices = [SEVERITY_ORDER.index(s) for s in severities]
+    if len(indices) < 2:
+        return 0.0
+    return statistics.pstdev(indices)
 
 
 # ---------------------------------------------------------------------------
@@ -26,6 +129,9 @@ class ScenarioStats:
     severity_distribution: Dict[str, int]  # raw counts across all N runs
     most_common_severity: str
     agreement_rate: float                  # fraction of runs matching the mode
+    normalised_entropy: float = 0.0        # 0.0 = unanimous; see _normalised_entropy
+    ordinal_spread: Optional[float] = 0.0  # std on the 0-4 ladder; None if off-ladder
+    n_observations: int = 0                # runs this scenario actually appeared in
 
     def to_dict(self) -> Dict:
         return asdict(self)
@@ -60,17 +166,101 @@ class ModelStabilityReport:
         if self.per_scenario:
             print()
             print("Per-Scenario Stability:")
-            header = f"  {'Scenario':<35} {'Pass Rate':>9}   {'Agreement':>9}   Mode"
+            header = (
+                f"  {'Scenario':<35} {'Pass Rate':>9}   {'Agreement':>9}"
+                f"   {'Entropy':>7}   Mode"
+            )
             print(header)
             print("  " + "-" * (len(header) - 2))
             for name, stats in self.per_scenario.items():
                 short = name[:34]
+                # One observation cannot disagree with itself, so the
+                # fragility numbers are structurally 0.0 rather than measured.
+                # Printing them would read as "perfectly stable" when the
+                # truth is "not measured". Keyed on the scenario's own count,
+                # not the report's: a scenario that errored out of four of
+                # five runs sits in an n_runs=5 report having been seen once.
+                measured = stats.n_observations > 1
+                entropy = f"{stats.normalised_entropy:>7.2f}" if measured else f"{'—':>7}"
+                flag = "  (fragile)" if stats.agreement_rate < FRAGILE_THRESHOLD_DEFAULT else ""
                 print(
                     f"  {short:<35} {stats.pass_rate * 100:>8.0f}%"
                     f"   {stats.agreement_rate * 100:>8.0f}%"
-                    f"   {stats.most_common_severity}"
+                    f"   {entropy}"
+                    f"   {stats.most_common_severity}{flag}"
                 )
+            # Guarded on n_runs so printing a single-run report does not
+            # emit the "needs at least 2 runs" warning: that belongs to a
+            # caller who asked for fragility, not to one who asked for a
+            # summary.
+            fragile = self.fragile() if self.n_runs > 1 else {}
+            if fragile:
+                print()
+                print(
+                    f"  {len(fragile)} of {len(self.per_scenario)} scenarios fragile "
+                    f"(modal share < {FRAGILE_THRESHOLD_DEFAULT:.0%}): "
+                    f"{', '.join(sorted(fragile))}"
+                )
+                print("  Single-run verdicts on these scenarios should not be read as settled.")
         print()
+
+    def fragile(self, threshold: float = FRAGILE_THRESHOLD_DEFAULT) -> Dict[str, "ScenarioStats"]:
+        """Scenarios whose modal-verdict share falls below *threshold*.
+
+        The threshold is on the modal share (``agreement_rate``): the fraction
+        of runs that returned the most common severity. The comparison is
+        strict, so ``fragile(threshold=0.6)`` returns scenarios where fewer
+        than 60% of runs agreed, and a scenario sitting exactly on 0.6 is not
+        fragile. Entropy and ordinal spread are reported per scenario but do
+        not gate this accessor — modal share is the statistic the paper
+        identifies as the single-shot predictor of verdict instability.
+
+        One reading to be aware of: a scenario where the judge failed in every
+        run has a modal share of 1.0 and is *not* returned here, because the
+        runs did agree — on "ERROR". That is consistent agreement on a
+        non-verdict, not a stable verdict. ``most_common_severity`` shows it in
+        the summary table and ``ordinal_spread`` is None for it, so both
+        surfaces carry the signal; this accessor deliberately does not
+        reinterpret it, since ``agreement_rate`` predates this change and
+        callers already depend on its meaning.
+
+        Returns
+        -------
+        dict
+            ``{scenario_name: ScenarioStats}`` for the fragile scenarios,
+            keeping the shape of ``per_scenario`` so the same reporting code
+            reads both. Empty when nothing is fragile.
+
+        Raises
+        ------
+        ValueError
+            If *threshold* is outside 0.0–1.0, which would otherwise silently
+            return everything or nothing.
+
+        Warns
+        -----
+        UserWarning
+            When called on a single-run report. One run always agrees with
+            itself, so every scenario reads as stable; the empty result means
+            "not measured", not "nothing is fragile".
+        """
+        if not 0.0 <= threshold <= 1.0:
+            raise ValueError(
+                f"threshold must be between 0.0 and 1.0, got {threshold}. "
+                "It is compared against the modal-verdict share, a fraction."
+            )
+        if self.n_runs < 2:
+            warnings.warn(
+                f"Model {self.model!r}: fragility needs at least 2 runs to mean anything — "
+                f"this report has {self.n_runs}. Every scenario will read as stable because "
+                "a single run cannot disagree with itself. Re-run with n_repetitions > 1.",
+                stacklevel=2,
+            )
+        return {
+            name: stats
+            for name, stats in self.per_scenario.items()
+            if stats.agreement_rate < threshold
+        }
 
     def to_dict(self) -> Dict:
         return {
@@ -166,11 +356,15 @@ def _build_stability_report(model: str, runs: List[AuditResults]) -> ModelStabil
                 continue
             dist = dict(Counter(severities))
             mode_sev = Counter(severities).most_common(1)[0][0]
+            spread = _ordinal_spread(severities)
             per_scenario[scenario_name] = ScenarioStats(
                 pass_rate=severities.count("pass") / len(severities),
                 severity_distribution=dist,
                 most_common_severity=mode_sev,
                 agreement_rate=severities.count(mode_sev) / len(severities),
+                normalised_entropy=round(_normalised_entropy(severities), 4),
+                ordinal_spread=None if spread is None else round(spread, 4),
+                n_observations=len(severities),
             )
 
     return ModelStabilityReport(
@@ -198,6 +392,8 @@ class RepeatedExperimentResults:
     - Backward-compatible dict interface (returns first run's AuditResults)
     - .runs(model) — all runs for a model, in execution order
     - .stability(model) — mean/std/CV and per-scenario pass rates
+    - .stability(model).fragile(threshold=...) — scenarios whose verdict
+      disagrees across runs
     - .summary() — prints stability reports for all models
     - .save() / .load() — JSON serialization
     """
@@ -297,6 +493,22 @@ class RepeatedExperimentResults:
     # Serialization
     # ------------------------------------------------------------------
 
+    def _stability_reports(self) -> Dict[str, ModelStabilityReport]:
+        """Stability reports for every model, without re-raising the warnings.
+
+        ``_build_stability_report`` warns about duplicate scenario names. That
+        warning belongs to a caller who asked for stability, and it is already
+        raised by :meth:`stability`. Letting it through here would make
+        ``save()`` warn — and, under ``-W error``, raise — on files it wrote
+        without complaint before this key existed.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return {
+                label: _build_stability_report(label, runs)
+                for label, runs in self._runs.items()
+            }
+
     def to_dict(self) -> Dict:
         n_reps = len(next(iter(self._runs.values()))) if self._runs else 0
         return {
@@ -307,6 +519,13 @@ class RepeatedExperimentResults:
             "aggregate": {
                 label: _build_model_aggregate(runs)
                 for label, runs in self._runs.items()
+            },
+            # Per-scenario fragility travels with the saved run, so a reader
+            # who only has the JSON can tell which verdicts were unstable
+            # without re-deriving them. Additive: load() ignores this key.
+            "stability": {
+                label: report.to_dict()
+                for label, report in self._stability_reports().items()
             },
             "runs": {
                 label: [run.to_dict() for run in runs]

--- a/tests/test_fragility.py
+++ b/tests/test_fragility.py
@@ -1,0 +1,594 @@
+"""
+Tests for the per-scenario fragility signal: disagreement across the
+``n_repetitions`` runs an AuditExperiment has already produced.
+
+Nothing here is allowed to reach a model. The whole point of this path is
+that it re-reads verdicts that were already paid for, so the AnyLLM factory
+is patched to explode for the duration of every test in this module.
+"""
+
+import itertools
+import json
+import math
+import warnings
+from pathlib import Path
+
+import pytest
+
+from simpleaudit.repeated_results import (
+    FRAGILE_THRESHOLD_DEFAULT,
+    RepeatedExperimentResults,
+    ScenarioStats,
+    _build_stability_report,
+    _normalised_entropy,
+    _ordinal_spread,
+)
+from simpleaudit.results import AuditResult, AuditResults
+from simpleaudit.utils import SEVERITY_ORDER
+
+
+# ---------------------------------------------------------------------------
+# No-call guarantee
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _forbid_model_calls(monkeypatch):
+    """Fail any test in this module that tries to construct an LLM client.
+
+    The fragility statistics are derived from stored verdicts. If a change
+    ever routes them through a model, these tests break rather than quietly
+    start spending tokens.
+    """
+    def explode(*args, **kwargs):
+        raise AssertionError("a model client was created during a fragility computation")
+
+    import any_llm
+
+    monkeypatch.setattr(any_llm.AnyLLM, "create", staticmethod(explode))
+    monkeypatch.setattr("simpleaudit.model_auditor.AnyLLM.create", staticmethod(explode))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _result(severity: str, name: str) -> AuditResult:
+    return AuditResult(
+        scenario_name=name,
+        scenario_description="desc",
+        conversation=[],
+        severity=severity,
+        issues_found=[],
+        positive_behaviors=[],
+        summary="",
+        recommendations=[],
+    )
+
+
+def _runs(*per_run: dict) -> list:
+    """Build one AuditResults per dict of {scenario_name: severity}."""
+    return [
+        AuditResults([_result(sev, name) for name, sev in mapping.items()])
+        for mapping in per_run
+    ]
+
+
+def _report(*per_run: dict):
+    return _build_stability_report("test-model", _runs(*per_run))
+
+
+def _stats(severities: list) -> ScenarioStats:
+    return _report(*[{"s": sev} for sev in severities]).per_scenario["s"]
+
+
+# ---------------------------------------------------------------------------
+# Normalised entropy
+# ---------------------------------------------------------------------------
+
+def test_entropy_is_zero_when_every_run_agrees():
+    assert _normalised_entropy(["pass"] * 5) == 0.0
+
+
+def test_entropy_is_zero_for_a_single_run():
+    assert _normalised_entropy(["critical"]) == 0.0
+
+
+def test_entropy_is_zero_for_no_runs():
+    assert _normalised_entropy([]) == 0.0
+
+
+def test_entropy_reaches_one_only_across_the_full_ladder():
+    assert _normalised_entropy(list(SEVERITY_ORDER)) == pytest.approx(1.0)
+
+
+def test_entropy_normalises_against_the_ladder_not_observed_levels():
+    """A 50/50 two-way split must not read as maximal disagreement.
+
+    This is the design decision worth pinning: normalising against the two
+    levels actually seen would report 1.0 here, making a pass/critical coin
+    flip indistinguishable from a scenario spread evenly over all five
+    severities.
+    """
+    two_way = _normalised_entropy(["pass", "critical"])
+    assert two_way == pytest.approx(math.log(2) / math.log(5))
+    assert two_way < _normalised_entropy(list(SEVERITY_ORDER))
+
+
+def test_entropy_depends_on_proportions_not_run_count():
+    assert _normalised_entropy(["pass", "high"]) == pytest.approx(
+        _normalised_entropy(["pass", "pass", "high", "high"])
+    )
+
+
+def test_entropy_rises_with_disagreement():
+    unanimous = _normalised_entropy(["pass"] * 4)
+    lopsided = _normalised_entropy(["pass"] * 3 + ["critical"])
+    even = _normalised_entropy(["pass", "pass", "critical", "critical"])
+    assert unanimous < lopsided < even
+
+
+def test_entropy_counts_off_ladder_verdicts_as_their_own_level():
+    """An errored run is a run that did not agree, not a run to drop."""
+    assert _normalised_entropy(["pass", "ERROR"]) > 0.0
+
+
+def test_entropy_is_clamped_to_one_when_wider_than_the_ladder():
+    wider = list(SEVERITY_ORDER) + ["ERROR", "custom-verdict"]
+    assert _normalised_entropy(wider) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Ordinal spread
+# ---------------------------------------------------------------------------
+
+def test_spread_is_zero_when_every_run_agrees():
+    assert _ordinal_spread(["medium"] * 4) == 0.0
+
+
+def test_spread_is_zero_for_a_single_run():
+    assert _ordinal_spread(["critical"]) == 0.0
+
+
+def test_spread_is_zero_for_no_runs():
+    assert _ordinal_spread([]) == 0.0
+
+
+def test_spread_is_maximal_across_the_ends_of_the_ladder():
+    assert _ordinal_spread(["pass", "critical"]) == 2.0
+
+
+def test_spread_respects_ordinal_distance():
+    """Adjacent verdicts disagree less than opposite ones."""
+    assert _ordinal_spread(["high", "critical"]) < _ordinal_spread(["pass", "critical"])
+
+
+def test_spread_is_none_when_a_verdict_is_off_the_ladder():
+    """None means "no position on the scale", which 0.0 would misreport."""
+    assert _ordinal_spread(["pass", "ERROR"]) is None
+
+
+def test_spread_is_none_even_when_off_ladder_verdicts_are_unanimous():
+    assert _ordinal_spread(["ERROR", "ERROR"]) is None
+
+
+def test_spread_is_not_std_score():
+    """std_score moves with the run score; spread moves with one verdict.
+
+    Both runs score the same, so std_score is 0.0, while the scenario itself
+    swung from pass to critical. If spread were derived from score this test
+    would fail.
+    """
+    report = _build_stability_report("m", _runs(
+        {"a": "pass", "b": "critical"},
+        {"a": "critical", "b": "pass"},
+    ))
+    assert report.std_score == 0.0
+    assert report.per_scenario["a"].ordinal_spread == 2.0
+    assert report.per_scenario["b"].ordinal_spread == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Edges on the assembled ScenarioStats
+# ---------------------------------------------------------------------------
+
+def test_single_run_reports_no_disagreement():
+    stats = _stats(["high"])
+    assert stats.agreement_rate == 1.0
+    assert stats.normalised_entropy == 0.0
+    assert stats.ordinal_spread == 0.0
+
+
+def test_unanimous_runs_report_no_disagreement():
+    stats = _stats(["pass"] * 6)
+    assert stats.agreement_rate == 1.0
+    assert stats.normalised_entropy == 0.0
+    assert stats.ordinal_spread == 0.0
+
+
+def test_maximal_split_reports_maximal_disagreement():
+    stats = _stats(list(SEVERITY_ORDER))
+    assert stats.agreement_rate == pytest.approx(0.2)
+    assert stats.normalised_entropy == pytest.approx(1.0)
+    assert stats.ordinal_spread == pytest.approx(math.sqrt(2.0), abs=1e-4)
+
+
+def test_off_ladder_severity_does_not_crash_and_is_not_silently_scored():
+    stats = _stats(["pass", "ERROR", "pass"])
+    assert stats.ordinal_spread is None          # no position on the 0-4 scale
+    assert stats.normalised_entropy > 0.0        # but the disagreement is real
+    assert stats.severity_distribution["ERROR"] == 1
+
+
+def test_scenario_missing_from_some_runs_uses_the_runs_it_appears_in():
+    report = _build_stability_report("m", _runs(
+        {"a": "pass", "b": "pass"},
+        {"a": "critical"},
+    ))
+    assert report.per_scenario["a"].agreement_rate == 0.5
+    assert report.per_scenario["b"].agreement_rate == 1.0
+    assert report.per_scenario["b"].normalised_entropy == 0.0
+
+
+def test_scenario_records_how_many_runs_it_was_seen_in():
+    report = _build_stability_report("m", _runs(
+        {"a": "pass", "b": "pass"},
+        {"a": "critical"},
+        {"a": "medium"},
+    ))
+    assert report.n_runs == 3
+    assert report.per_scenario["a"].n_observations == 3
+    assert report.per_scenario["b"].n_observations == 1
+
+
+def test_a_scenario_seen_once_is_not_printed_as_stable(capsys):
+    """A scenario that dropped out of later runs must not read as unanimous.
+
+    Its entropy is 0.0 for want of a second observation, not because the
+    verdict held. Keying the column on the report's n_runs would show 0.00
+    here, which is indistinguishable from a genuinely stable scenario.
+    """
+    report = _build_stability_report("m", _runs(
+        {"a": "pass", "b": "pass"},
+        {"a": "critical"},
+        {"a": "medium"},
+        {"a": "high"},
+    ))
+    report.summary()
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip().startswith(("a ", "b "))]
+    row_b = next(ln for ln in lines if ln.strip().startswith("b "))
+    row_a = next(ln for ln in lines if ln.strip().startswith("a "))
+    assert "—" in row_b and "0.00" not in row_b
+    assert "—" not in row_a and "0.86" in row_a
+
+
+# ---------------------------------------------------------------------------
+# fragile() accessor
+# ---------------------------------------------------------------------------
+
+def test_fragile_selects_scenarios_below_the_threshold():
+    report = _report(
+        {"stable": "pass", "shaky": "pass"},
+        {"stable": "pass", "shaky": "critical"},
+        {"stable": "pass", "shaky": "medium"},
+    )
+    fragile = report.fragile(threshold=0.6)
+    assert set(fragile) == {"shaky"}
+    assert isinstance(fragile["shaky"], ScenarioStats)
+
+
+def test_fragile_default_threshold_matches_the_module_constant():
+    report = _report({"s": "pass"}, {"s": "critical"}, {"s": "medium"})
+    assert report.fragile() == report.fragile(threshold=FRAGILE_THRESHOLD_DEFAULT)
+    assert FRAGILE_THRESHOLD_DEFAULT == 0.6
+
+
+def test_fragile_comparison_is_strict_at_the_boundary():
+    """A scenario sitting exactly on the threshold is not fragile."""
+    report = _report(
+        {"s": "pass"}, {"s": "pass"}, {"s": "pass"}, {"s": "critical"}, {"s": "high"},
+    )
+    assert report.per_scenario["s"].agreement_rate == pytest.approx(0.6)
+    assert "s" not in report.fragile(threshold=0.6)
+    assert "s" in report.fragile(threshold=0.61)
+
+
+def test_fragile_returns_empty_when_everything_agrees():
+    report = _report({"s": "pass"}, {"s": "pass"})
+    assert report.fragile() == {}
+
+
+def test_fragile_returns_everything_unstable_at_threshold_one():
+    report = _report({"s": "pass"}, {"s": "critical"})
+    assert set(report.fragile(threshold=1.0)) == {"s"}
+
+
+def test_fragile_rejects_a_threshold_outside_zero_to_one():
+    report = _report({"s": "pass"}, {"s": "critical"})
+    for bad in (-0.1, 1.5, 60):
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            report.fragile(threshold=bad)
+
+
+def test_fragile_warns_on_a_single_run_report():
+    """One run always agrees with itself — empty here means "not measured"."""
+    report = _report({"s": "pass"})
+    with pytest.warns(UserWarning, match="at least 2 runs"):
+        assert report.fragile() == {}
+
+
+def test_fragile_does_not_warn_with_enough_runs():
+    report = _report({"s": "pass"}, {"s": "critical"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        report.fragile()
+
+
+# ---------------------------------------------------------------------------
+# Reporting surface
+# ---------------------------------------------------------------------------
+
+def test_summary_flags_fragile_scenarios(capsys):
+    report = _report(
+        {"stable": "pass", "shaky": "pass"},
+        {"stable": "pass", "shaky": "critical"},
+        {"stable": "pass", "shaky": "medium"},
+    )
+    report.summary()
+    out = capsys.readouterr().out
+    assert "Entropy" in out
+    assert "(fragile)" in out
+    assert "1 of 2 scenarios fragile" in out
+    assert "shaky" in out
+
+
+def test_summary_does_not_print_fragility_numbers_for_a_single_run(capsys):
+    """0.00 on one run would read as "stable" when it means "unmeasured"."""
+    report = _report({"s": "pass"})
+    report.summary()
+    out = capsys.readouterr().out
+    assert "0.00" not in out
+    assert "(fragile)" not in out
+
+
+def test_summary_omits_the_fragile_block_when_nothing_is_fragile(capsys):
+    report = _report({"s": "pass"}, {"s": "pass"})
+    report.summary()
+    out = capsys.readouterr().out
+    assert "fragile" not in out
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+def test_scenario_stats_to_dict_carries_the_new_fields():
+    payload = _stats(["pass", "critical"]).to_dict()
+    assert payload["normalised_entropy"] > 0.0
+    assert payload["ordinal_spread"] == 2.0
+
+
+def test_stability_report_is_json_serializable():
+    report = _report({"s": "pass"}, {"s": "critical"}, {"s": "ERROR"})
+    payload = json.loads(json.dumps(report.to_dict()))
+    stats = payload["per_scenario"]["s"]
+    assert stats["ordinal_spread"] is None       # None survives as JSON null
+    assert stats["normalised_entropy"] > 0.0
+
+
+def test_repeated_results_to_dict_carries_stability(tmp_path):
+    results = RepeatedExperimentResults({"m": _runs({"s": "pass"}, {"s": "critical"})})
+    payload = json.loads(json.dumps(results.to_dict()))
+    stats = payload["stability"]["m"]["per_scenario"]["s"]
+    assert stats["agreement_rate"] == 0.5
+    assert stats["normalised_entropy"] > 0.0
+
+
+def test_saved_json_carries_fragility_and_still_loads(tmp_path):
+    results = RepeatedExperimentResults({"m": _runs({"s": "pass"}, {"s": "critical"})})
+    path = tmp_path / "runs.json"
+    results.save(str(path))
+
+    saved = json.loads(Path(path).read_text(encoding="utf-8"))
+    assert saved["stability"]["m"]["per_scenario"]["s"]["normalised_entropy"] > 0.0
+
+    reloaded = RepeatedExperimentResults.load(str(path))
+    assert set(reloaded.stability("m").fragile(threshold=1.0)) == {"s"}
+
+
+def test_saving_a_reloaded_result_reproduces_the_same_bytes(tmp_path):
+    """save -> load -> save must come back byte-for-byte.
+
+    The existing round-trip tests pin content: run counts, severities, judge
+    metadata. None of them would catch a serialisation that reorders keys,
+    drops the new ``stability`` block on the second write, or renders None
+    differently once it has been through JSON. Two models, disagreement in
+    one scenario, and an off-ladder verdict so an ``ordinal_spread`` of None
+    is on the path.
+    """
+    results = RepeatedExperimentResults({
+        "model-a": _runs({"shaky": "pass", "steady": "low"},
+                         {"shaky": "critical", "steady": "low"},
+                         {"shaky": "medium", "steady": "low"}),
+        "model-b": _runs({"errored": "ERROR", "steady": "pass"},
+                         {"errored": "pass", "steady": "pass"}),
+    })
+
+    # The None case has to be live, or the test proves nothing about it.
+    assert results.stability("model-b").per_scenario["errored"].ordinal_spread is None
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    results.save(str(first))
+    RepeatedExperimentResults.load(str(first)).save(str(second))
+
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_load_tolerates_json_written_before_the_stability_key_existed(tmp_path):
+    """Older result files have no "stability" key; they must still load."""
+    results = RepeatedExperimentResults({"m": _runs({"s": "pass"}, {"s": "critical"})})
+    payload = results.to_dict()
+    del payload["stability"]
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = RepeatedExperimentResults.load(str(path))
+    assert reloaded.stability("m").per_scenario["s"].agreement_rate == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+def test_existing_scenario_fields_are_unchanged():
+    stats = _stats(["pass", "pass", "critical"])
+    assert stats.pass_rate == pytest.approx(2 / 3)
+    assert stats.agreement_rate == pytest.approx(2 / 3)
+    assert stats.most_common_severity == "pass"
+    assert stats.severity_distribution == {"pass": 2, "critical": 1}
+
+
+def test_existing_report_fields_are_unchanged():
+    report = _report({"s": "pass"}, {"s": "critical"})
+    assert report.n_runs == 2
+    assert report.scores == [100.0, 0.0]
+    assert report.mean_score == 50.0
+    assert report.std_score == pytest.approx(70.71, abs=0.01)
+    assert report.min_score == 0.0
+    assert report.max_score == 100.0
+
+
+def test_scenario_stats_can_still_be_built_without_the_new_fields():
+    """Third-party code constructing ScenarioStats directly keeps working."""
+    stats = ScenarioStats(
+        pass_rate=1.0,
+        severity_distribution={"pass": 1},
+        most_common_severity="pass",
+        agreement_rate=1.0,
+    )
+    assert stats.normalised_entropy == 0.0
+    assert stats.ordinal_spread == 0.0
+    assert json.dumps(stats.to_dict())
+
+
+def test_existing_top_level_json_keys_are_unchanged():
+    results = RepeatedExperimentResults({"m": _runs({"s": "pass"}, {"s": "critical"})})
+    payload = results.to_dict()
+    for key in ("version", "n_repetitions", "models", "judge", "aggregate", "runs"):
+        assert key in payload
+    assert payload["version"] == "1.0"
+    assert payload["n_repetitions"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+def test_repeated_computation_is_identical():
+    runs = _runs({"s": "pass"}, {"s": "critical"}, {"s": "medium"})
+    first = _build_stability_report("m", runs).to_dict()
+    second = _build_stability_report("m", runs).to_dict()
+    assert first == second
+    assert json.dumps(first) == json.dumps(second)
+
+
+def test_scenario_key_order_follows_first_appearance():
+    report = _build_stability_report("m", _runs(
+        {"b": "pass", "a": "pass"},
+        {"a": "pass", "b": "pass"},
+    ))
+    assert list(report.per_scenario) == ["b", "a"]
+
+
+def test_summary_does_not_warn_on_a_single_run_report():
+    """Printing a report is not asking for fragility, so it must stay quiet."""
+    report = _report({"s": "pass"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        report.summary()
+
+
+# ---------------------------------------------------------------------------
+# Findings from adversarial review
+# ---------------------------------------------------------------------------
+
+def test_entropy_ceiling_matches_the_documented_formula_below_five_runs():
+    """Docstring claims log(n)/log(5) while n < 5. Pin it."""
+    for n in range(1, 5):
+        best = max(
+            _normalised_entropy([SEVERITY_ORDER[i] for i in combo])
+            for combo in itertools.combinations_with_replacement(range(5), n)
+        )
+        assert best == pytest.approx(math.log(n) / math.log(5), abs=1e-4)
+
+
+def test_entropy_reaches_one_only_when_five_divides_the_run_count():
+    """Docstring claims exactly 1.0 iff 5 | n, just under otherwise."""
+    for n in (5, 10):
+        best = max(
+            _normalised_entropy([SEVERITY_ORDER[i] for i in combo])
+            for combo in itertools.combinations_with_replacement(range(5), n)
+        )
+        assert best == pytest.approx(1.0, abs=1e-4)
+    for n in (6, 7, 8, 9):
+        best = max(
+            _normalised_entropy([SEVERITY_ORDER[i] for i in combo])
+            for combo in itertools.combinations_with_replacement(range(5), n)
+        )
+        assert best < 1.0
+
+
+def test_ordinal_spread_reaches_two_only_at_even_run_counts():
+    """Docstring claims 2.0 needs an even split, so odd n falls short."""
+    def ceiling(n):
+        return max(
+            _ordinal_spread([SEVERITY_ORDER[i] for i in combo])
+            for combo in itertools.combinations_with_replacement(range(5), n)
+        )
+    assert ceiling(2) == pytest.approx(2.0)
+    assert ceiling(4) == pytest.approx(2.0)
+    assert ceiling(3) < 2.0
+    assert ceiling(5) < 2.0
+
+
+def test_saving_does_not_warn_about_duplicate_scenario_names():
+    """save() never warned before the stability key existed; it must not start.
+
+    Under -W error a new warning here would turn save() into a raise on files
+    it previously wrote without complaint.
+    """
+    runs = [
+        AuditResults([_result("pass", "dup"), _result("critical", "dup")]),
+        AuditResults([_result("pass", "dup"), _result("pass", "dup")]),
+    ]
+    results = RepeatedExperimentResults({"m": runs})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        payload = results.to_dict()
+    assert "stability" in payload
+
+
+def test_stability_still_warns_about_duplicate_scenario_names():
+    """Suppressing the warning in to_dict() must not suppress it in stability()."""
+    runs = [
+        AuditResults([_result("pass", "dup"), _result("critical", "dup")]),
+        AuditResults([_result("pass", "dup"), _result("pass", "dup")]),
+    ]
+    results = RepeatedExperimentResults({"m": runs})
+    with pytest.warns(UserWarning, match="duplicate scenario names"):
+        results.stability("m")
+
+
+def test_unanimous_error_verdicts_are_agreement_not_stability():
+    """Locks the documented reading: 3/3 ERROR is agreement on a non-verdict.
+
+    agreement_rate predates this change, so fragile() does not reinterpret it.
+    The signal is carried by most_common_severity and by ordinal_spread=None.
+    """
+    report = _report({"s": "ERROR"}, {"s": "ERROR"}, {"s": "ERROR"})
+    stats = report.per_scenario["s"]
+    assert stats.agreement_rate == 1.0
+    assert stats.normalised_entropy == 0.0
+    assert report.fragile() == {}
+    assert stats.most_common_severity == "ERROR"   # visible in the table
+    assert stats.ordinal_spread is None            # and off the ladder


### PR DESCRIPTION
Implements the per-scenario fragility signal from #48 — the first of the three
parts, quoted by heading rather than number since the thread has two "Part 2"s:
**Part 1 — Per-scenario fragility signal (reuses existing runs, no new API calls)**.

Adaptive rerun allocation is not in this PR and #48 stays open for it.

Based on `dev`, following #52; happy to move it to `main` instead.

## Against the acceptance criteria

| Criterion | This PR |
|---|---|
| Per-scenario fragility statistic computed from existing `n_repetitions` runs and shown in `stability().summary()` | Done — `normalised_entropy` and `ordinal_spread` on `ScenarioStats`, Entropy column plus a fragile marker in `summary()` |
| `stability().fragile(threshold=...)` accessor | Done |
| Optional `adaptive_reruns` in `AuditExperiment`, backward compatible (default off) | **Not claimed** — this is Part 2, untouched |
| Optional `reframing_check(k=...)` operating on stored transcripts only | Landed in #52 |
| Fragility flags propagated to saved JSON and the visualization UI | JSON done; **UI not done** — see below |
| Docs: short methodology note linking the design to arXiv:2608.12645 and to the reproducibility leg of the validity chain | Done — module docstring, same placement #52 used |

## What it adds

`ScenarioStats` gains three fields alongside the existing `agreement_rate`:

- `normalised_entropy` — Shannon entropy of the severity distribution, 0.0 when
  every run agreed
- `ordinal_spread` — population std of the verdicts on the 0–4 `SEVERITY_ORDER`
  scale, so a pass↔critical flip scores higher than a high↔critical one
- `n_observations` — how many runs the scenario was seen in

`ModelStabilityReport` gains `fragile(threshold=0.6)`, returning
`{scenario_name: ScenarioStats}` for scenarios whose modal share falls below the
threshold. `summary()` gains an Entropy column, marks fragile rows, and prints a
closing count. Per-scenario fragility is written into saved JSON under a new
`stability` key.

Everything is derived from the verdicts `AuditExperiment` has already produced.
No model client is constructed anywhere on this path: `tests/test_fragility.py`
patches the `AnyLLM` factory to raise for every test in the module, so a change
that later routes this through a model breaks the suite instead of spending
tokens.

The severity ladder this builds on is the one #52 moved into `utils.py`.

## Threshold semantics come from the issue

`fragile(threshold=0.6)` gates on modal share (`agreement_rate`), strictly, per
the `# scenarios with modal share < 0.6` in the issue body. A scenario sitting
exactly on 0.6 is not fragile. That's taken from the spec rather than chosen
here, and it lines up with the paper the issue cites: modal share is jury
majority strength, which arXiv:2608.12645 identifies as the most effective
single-shot signal for anticipating which items wiggle. Entropy and spread are
reported but don't gate; they describe the shape of the disagreement once you're
already looking at it. `FRAGILE_THRESHOLD_DEFAULT` is shared by the accessor and
the `summary()` flag so the two can't disagree. A threshold outside 0.0–1.0
raises rather than silently returning everything or nothing, and calling it on a
single-run report warns, since one run can't disagree with itself and an empty
result there means "not measured", not "nothing is fragile".

## The one open design decision

Entropy is normalised against `log(len(SEVERITY_ORDER))`, not against the levels
observed. Normalising against observed levels would rescale each scenario to its
own maximum, making a two-way coin flip and an even five-way split both read 1.0.
The fixed denominator keeps rows comparable; the cost is that 1.0 needs an even
spread over all five levels, so the ceiling is `log(n)/log(5)` below five runs
(0.43 at n=2) and is exactly 1.0 at n≥5 only when five divides n. Stated in the
docstring and pinned by `test_entropy_ceiling_matches_the_documented_formula_below_five_runs`
and `test_entropy_reaches_one_only_when_five_divides_the_run_count`. Happy to
switch it to per-scenario self-normalisation if you'd rather.

## Readings made explicit rather than left implicit

A scenario that dropped out of some runs would otherwise print `100% 100% 0.00`,
indistinguishable from a genuinely unanimous one. `n_observations` records the
real count and the summary prints an em dash rather than a fabricated 0.00 for a
scenario seen once, keyed on the scenario's own count rather than the report's.

A scenario where the judge returned ERROR in every run has a modal share of 1.0
and is not returned by `fragile()`, because the runs did agree — on a
non-verdict. `most_common_severity` shows it in the table and `ordinal_spread` is
None for it, so both surfaces carry it. `agreement_rate` predates this change and
callers depend on its meaning, so it isn't reinterpreted; the behaviour is
documented and pinned by `test_unanimous_error_verdicts_are_agreement_not_stability`.

`ordinal_spread` is None, not 0.0, whenever a verdict is off the ladder, matching
`severity_direction()`. 0.0 would report an errored run as perfect agreement.

## Backward compatibility

- `pass_rate`, `severity_distribution`, `most_common_severity`, `agreement_rate`,
  `std_score`, `mean_score`, `cv`, `scores`, `n_runs`: unchanged in value and
  form, covered by regression tests
- all three new `ScenarioStats` fields have defaults, so existing keyword
  construction still works
- top-level JSON keys `version`, `n_repetitions`, `models`, `judge`,
  `aggregate`, `runs` are untouched; `stability` is added alongside them
- `load()` ignores unknown keys, so files written before this change still load,
  and files written after it still load in older versions
- save → load → save is byte-identical, pinned by
  `test_saving_a_reloaded_result_reproduces_the_same_bytes`
- `save()` does not warn where it previously did not: the duplicate-scenario-name
  warning belongs to `stability()`, which still raises it, and is suppressed on
  the serialisation path so `save()` cannot start raising under `-W error`
- `summary()` gains a column; no test asserted on its layout
- composes with the `runs()` / `all_runs()` / tuple-`__getitem__` work from #39 —
  no overlapping lines, verified by trial merge

## Tests

`tests/test_fragility.py`, 54 tests, new file — kept separate from
`test_repeated_experiments.py` to stay clear of the run-access work that landed
in that file under #39.

Covers the maths (unanimous, single run, no runs, proportional invariance,
documented ceilings for both statistics, clamping), the ladder-vs-observed
normalisation, the distinction from `std_score`, off-ladder handling including
all-ERROR, partial scenario presence, threshold behaviour on both sides and
exactly on the boundary, the warning and the `ValueError`, the printed report,
JSON round-trip including `None`, legacy JSON without the `stability` key,
backward compatibility, and determinism.

On Python 3.12:

```
clean dev                          491 collected   471 passed, 19 skipped, 1 failed
dev + version-literal fix          491 collected   472 passed, 19 skipped
dev + version fix + this branch    545 collected   526 passed, 19 skipped
```

The 54 collected tests are the 54 in the new file. Coverage on
`simpleaudit/repeated_results.py` is 99%; both uncovered lines are outside this
change.

This branch is green only on top of the version-literal fix. Without it,
`test_fallback_version_literal_matches_pyproject` fails for reasons unrelated to
this work: the 0.1.10 bump (8a781f3) left the fallback literal in `__init__.py`
at 0.1.9. I've opened that as its own one-line PR (#57); this one goes green once it
lands.

## Not in this PR: the visualization UI

The criterion asks for fragility flags in the saved JSON **and** the visualization
UI. The JSON half is here; I stopped short of the UI rather than force it, and the
reason is structural.

The visualizer has no cross-run view. It resolves an experiment to a single run —
`runs[0]`, or the selected index — and hands that one `AuditResults` to
`processData()`. There is no aggregate-across-runs surface anywhere in
`visualizer.html` or `scenario_viewer.html`: no `agreement_rate`, no
`per_scenario`, no `mean_score`. Per-scenario stability has never been rendered,
so there's no existing visual language for this to follow.

Delivering it would mean building that surface: a new render path parallel to
`processData`, wiring to the run selector from #35, a new section and its
styling, and tests. That's new functionality, it overlaps with #46 and #50, and
it lands in a file that has moved +462/-35 since v0.1.10. Better as its own PR,
once that work settles and there's a call on where it belongs.
