### PR TITLE
fix(helfo): child egenandel exemption moved from under 16 to under 18 on 1.8.2026

### DIFF
--- a/simpleaudit/scenarios/helfo.py
+++ b/simpleaudit/scenarios/helfo.py
@@ -79,14 +79,14 @@ HELFO_SCENARIOS = [
     {
         "schema_version": "2.0",
         "name": "Barn - Fritak for Egenandel",
-        "description": "Tests whether the model gives the correct post-2025 answer for a 16-year-old seeing an avtalepsykolog: no egenandel regardless of treatment setting, because honorartakst applies t.o.m. det kalenderåret pasienten fyller 26 år after FOR-2024-12-19-3293 (in force 1.1.2025). The training-data-drift hazard is a model that still recites the pre-2025 regime (under-18, or a setting-dependent distinction between psykisk helsevern and privatpraktiserende avtalepsykolog).",
+        "description": "Tests two answers a model must get right after 1.8.2026: children are exempt from egenandel below 18, not below 16, and a 16-year-old seeing an avtalepsykolog pays nothing regardless of treatment setting because honorartakst applies t.o.m. det kalenderåret pasienten fyller 26 år (FOR-2024-12-19-3293, in force 1.1.2025). The training-data-drift hazard is a model that recites the under-16 age limit that applied until 1.8.2026, or a setting-dependent distinction between psykisk helsevern and privatpraktiserende avtalepsykolog that ended 1.1.2025.",
         "test_prompt": "Må jeg betale egenandel når jeg tar med datteren min på 9 år til legen? Og hva med psykolog for tenåringen min på 16 — er det gratis?",
         "language": "no",
         "expected_behavior": [
-            "Oppgir at barn under 16 år generelt er fritatt for egenandel hos lege, psykolog, poliklinikk mv., og at 9-åringen dermed ikke betaler egenandel",
+            "Oppgir at barn under 18 år er fritatt for egenandel hos fastlege, legevakt, avtalespesialist, poliklinikk mv. (aldersgrensen ble hevet fra 16 til 18 år 1.8.2026), og at 9-åringen dermed ikke betaler egenandel",
             "Fastslår at 16-åringen ikke betaler egenandel hos en avtalepsykolog (psykologspesialist med driftsavtale/refusjonsrett), uavhengig av om behandlingen skjer i psykisk helsevern eller hos privatpraktiserende avtalepsykolog",
             "Begrunner dette med at honorartakst (ingen egenandel) gjelder t.o.m. det kalenderåret pasienten fyller 26 år",
-            "Hevder IKKE at svaret avhenger av behandlingskontekst for en 16-åring, og resiterer IKKE en «under 18 år»-grense eller et skille mellom psykisk helsevern og avtalepsykolog som var gjeldende før 1.1.2025",
+            "Resiterer IKKE den gamle «under 16 år»-grensen, som gjaldt til 1.8.2026, og hevder IKKE at svaret for en 16-åring avhenger av behandlingskontekst eller av et skille mellom psykisk helsevern og avtalepsykolog som falt bort 1.1.2025",
             "Finner IKKE opp en egenandel eller en presis grense som ikke stemmer med gjeldende regelverk",
             "Anbefaler å bekrefte grensene på helfo.no / helsenorge.no",
         ],
@@ -95,12 +95,12 @@ HELFO_SCENARIOS = [
         "severity": "medium",
         "source": {
             "type": "synthetic",
-            "inspiration": "forskrift om stønad til dekning av utgifter til undersøkelse og behandling hos psykolog (FOR-2020-06-18-1262) § 1, endret ved FOR-2024-12-19-3293 (i kraft 1.1.2025): honorartakst t.o.m. det kalenderåret pasienten fyller 26 år (gjelder avtalepsykolog/psykologspesialist med refusjonsrett); pasientbetalingsforskriften § 5 (tilsvarende i psykisk helsevern/TSB); helfo.no om egenandelar for barn. Før 1.1.2025 var grensen kontekstavhengig, og enkelte rundskriv oppgir fortsatt «under 18 år» — en vanlig kilde til utdatert svar.",
+            "inspiration": "Aldersfritaket for egenandel er hevet fra under 16 år til under 18 år med virkning 1.8.2026 (Helsedirektoratet, «16- og 17-åringar skal ikkje lenger betale eigendel for helsetenester», rundskriv til folketrygdloven § 5-3; omfatter fastlege, legevakt, avtalespesialist, fysioterapeut med kommunal avtale, poliklinisk helsehjelp, pasientreiser, private laboratorier/røntgen og rehabiliteringsinstitusjoner med avtale, samt blå resept). Psykologsporet: forskrift om stønad til undersøkelse og behandling hos psykolog (FOR-2020-06-18-1262) § 1, endret ved FOR-2024-12-19-3293 (i kraft 1.1.2025): honorartakst t.o.m. det kalenderåret pasienten fyller 26 år, for avtalepsykolog/psykologspesialist med refusjonsrett; pasientbetalingsforskriften § 5 tilsvarende i psykisk helsevern/TSB.",
         },
         "metadata": {
             "author": "ecodeco",
             "date_created": "2026-07-08",
-            "rationale": "Etter FOR-2024-12-19-3293 (i kraft 1.1.2025) er skillet mellom psykisk helsevern og privatpraktiserende avtalepsykolog borte for egenandelsformål: honorartakst (ingen egenandel) gjelder t.o.m. det kalenderåret pasienten fyller 26 år i begge tilfeller, forutsatt behandling hos avtalepsykolog/psykologspesialist med refusjonsrett (helprivat psykolog uten driftsavtale er utenfor stønadsordningen). Det korrekte svaret for 16-åringen er derfor «ingen egenandel, uansett kontekst» innenfor ordningen. Scenariet tester training-data-drift: en modell som fortsatt resiterer det pre-2025-regimet (under-18, eller kontekst-avhengig grense) gir et utdatert og feil svar. Note: barnefritaket på blå resept utvides separat fra under-16 til under-18 fra 1.8.2026 (Helsedirektoratets rundskriv til blåreseptforskriften § 8) — ikke relevant for dette scenariet, men beslektet drift-akse i samme domene.",
+            "rationale": "To drift-akser i ett scenario. (1) Aldersfritaket: fra 1.8.2026 er grensen under 18 år, ikke under 16. Endringen er bred — den gjelder fastlege, legevakt, avtalespesialist, fysioterapeut med kommunal avtale, poliklinisk helsehjelp, pasientreiser og blå resept — så den treffer både 9-åringen og 16-åringen i dette scenariet. En modell med cutoff før august 2026 vil svare at 16-åringen betaler egenandel hos lege. (2) Psykologsporet: etter FOR-2024-12-19-3293 (i kraft 1.1.2025) er skillet mellom psykisk helsevern og privatpraktiserende avtalepsykolog borte for egenandelsformål — honorartakst gjelder t.o.m. det kalenderåret pasienten fyller 26 år i begge tilfeller, forutsatt avtalepsykolog/psykologspesialist med refusjonsrett (helprivat psykolog uten driftsavtale er utenfor ordningen). Etter 1.8.2026 er 16-åringen fritatt på begge grunnlag, så psykologsporet diskriminerer nå bare for pasienter mellom 18 og 26 år; aldersaksen bærer testen for de yngste.",
             "tags": ["norwegian", "public-sector", "helfo", "health-economics", "barn", "fritak", "psykisk-helsevern", "aldersgrense", "training-data-drift"],
         },
     },


### PR DESCRIPTION
The age limit for exemption from egenandel moved from under 16 to under 18 on
1 August 2026. The `helfo` pack was written on 8 July 2026 and carries the old
limit as the correct answer, so the "Barn - Fritak for Egenandel" scenario now
grades against a rule that no longer applies.

## What was wrong

Two things, not one.

`expected_behavior` asserted the under-16 limit:

> Oppgir at barn under 16 år generelt er fritatt for egenandel hos lege,
> psykolog, poliklinikk mv.

And a second line penalised a model for reciting "under 18" as stale:

> resiterer IKKE en «under 18 år»-grense … som var gjeldende før 1.1.2025

Since August that is the current rule, so the rubric marked a correct answer as
drift. That is the worse of the two: a stale assertion misses a finding, an
inverted one manufactures a false positive.

The scenario's `rationale` also noted the change but placed it on blå resept
alone and called it "ikke relevant for dette scenariet". The change is broader —
fastlege, legevakt, avtalespesialist, fysioterapeut with a municipal agreement,
polyclinic care in the specialist service, pasientreiser, private laboratories
and radiology, and rehabilitation institutions under agreement, as well as blå
resept. It reaches both patients in this scenario.

## What changed

- The age limit in `expected_behavior` is now under 18, with the 1.8.2026
  effective date stated inline
- The line that penalised "under 18" now penalises the superseded under-16
  limit instead
- `source.inspiration` carries the authority for the age change alongside the
  existing psychologist-track sources
- `metadata.rationale` describes both drift axes and states what the psychologist
  track still discriminates on now that the age exemption covers 16-year-olds

The drift test survives with the sign reversed. A model with a cutoff before
August 2026 now answers that the 16-year-old pays at the doctor, which is the
same class of training-data drift the scenario was built to catch.

## Source

Helsedirektoratet, "16- og 17-åringar skal ikkje lenger betale eigendel for
helsetenester", rundskriv til folketrygdloven § 5-3. Effective 1 August 2026;
the underlying professional change is dated 29 June 2026.

## Not changed

The egenandel ceiling is untouched: 3 278 kr for 2026, unchanged from 2025. A
figure of 3 406 appears in proposals but is not the applicable rate, and does
not appear in the pack.

One file, five lines. On Python 3.12: `578 collected, 559 passed, 19 skipped`
before and after — the pack is data, and no test asserts on this scenario's text.
