### PR TITLE
Scenario pack conventions, checker and review checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,13 @@ results = auditor.run("rag")
 results = auditor.run("all")
 ```
 
+Contributing a pack: follow the
+[scenario guidelines](simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md)
+(section "Pack Conventions"), start the pack README from
+[the template](simpleaudit/scenarios/PACK_README_TEMPLATE.md), run
+`python scripts/check_scenario_pack.py <pack>` before opening the PR, and expect the review to
+follow the [pack review checklist](simpleaudit/scenarios/PACK_REVIEW_CHECKLIST.md).
+
 ### Vision Integrity
 
 `vision_integrity` is the first pack that attaches images (via `file_uri`). It tests the same

--- a/scripts/check_scenario_pack.py
+++ b/scripts/check_scenario_pack.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Structural checks for a SimpleAudit scenario pack.
+
+    python scripts/check_scenario_pack.py <pack_name> [--repo PATH]
+
+The rules come from simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md
+(section "Pack Conventions") and tests/test_scenario_data.py. Findings are tagged
+ERROR (must fix), WARN (fix or explain in the PR) or INFO (for the reviewer).
+Exit code is 1 when any ERROR is present. tests/test_scenario_pack_conventions.py
+runs the ERROR-level rules in CI for the packs listed there.
+
+Standard library only.
+"""
+
+import argparse
+import difflib
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+TAXONOMY = {
+    "Mental Health": {"Crisis Response", "Self-Harm", "Anxiety", "Depression", "Eating Disorders", "Diagnosis"},
+    "Substance Safety": {"Medications", "Recreational Drugs", "Alcohol", "Overdose"},
+    "Privacy": {"Data Security", "Confidentiality", "Anonymity"},
+    "Age-Appropriate": {"Youth-Specific", "Parental Guidance", "Maturity-Matched"},
+    "Identity & Relationships": {"LGBTQ+", "Family Conflict", "Peer Relationships", "Bullying"},
+    "Physical Safety": {"Abuse", "Violence", "Emergency Situations"},
+    "Harmful Content": {"Misinformation", "Dangerous Advice", "Illegal Activities"},
+    "System Integrity": {"Prompt Injection", "Jailbreaking", "Role Confusion", "Hallucination"},
+}
+SEVERITIES = {"low", "medium", "high", "critical"}
+SOURCE_TYPES = {"real_case", "synthetic", "adapted"}
+BRANCHES = {"majority", "outlier", "third"}
+PAIR_TYPES = {"matched", "branch_set"}
+REQUIRED = ["schema_version", "name", "description", "test_prompt", "language",
+            "expected_behavior", "category", "subcategory", "severity", "source", "metadata"]
+EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+ROWID_RE = re.compile(r"\b[A-Z]{2,6}-\d{2}\b")
+JUDGE_NOTE_RE = re.compile(r"^\s*(MERK FOR DOMMEREN|JUDGE NOTE|NOTE TO JUDGE)\b", re.I)
+SEVERITY_WORD_RE = re.compile(r"\b(pass|low|medium|high|critical|bestått|lav|middels|høy|kritisk)\b", re.I)
+PAIR_SIMILARITY_FLOOR = 0.75
+
+
+class Report:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, level, where, msg):
+        self.rows.append((level, where, msg))
+
+    def error(self, where, msg):
+        self.add("ERROR", where, msg)
+
+    def warn(self, where, msg):
+        self.add("WARN", where, msg)
+
+    def info(self, where, msg):
+        self.add("INFO", where, msg)
+
+    @property
+    def errors(self):
+        return [r for r in self.rows if r[0] == "ERROR"]
+
+    def render(self):
+        out = []
+        for level in ("ERROR", "WARN", "INFO"):
+            rows = [r for r in self.rows if r[0] == level]
+            if not rows:
+                continue
+            out.append(f"\n### {level} ({len(rows)})\n")
+            out.extend(f"- [{where}] {msg}" for _, where, msg in rows)
+        return "\n".join(out)
+
+
+def prompt_diff(a, b):
+    """Return (similarity ratio, changed tokens in a, changed tokens in b)."""
+    ta, tb = a.split(), b.split()
+    sm = difflib.SequenceMatcher(None, ta, tb)
+    da, db = [], []
+    for op, i1, i2, j1, j2 in sm.get_opcodes():
+        if op != "equal":
+            da.extend(ta[i1:i2])
+            db.extend(tb[j1:j2])
+    return sm.ratio(), " ".join(da), " ".join(db)
+
+
+def check_scenarios(pack, scenarios, rep):
+    names = Counter(s.get("name") for s in scenarios)
+    prompts = Counter(s.get("test_prompt") for s in scenarios)
+    pairs = defaultdict(list)
+    sev, cat, lang = Counter(), Counter(), Counter()
+    eb_len = []
+
+    for i, s in enumerate(scenarios):
+        w = s.get("name") or f"#{i}"
+        for k in REQUIRED:
+            if k not in s:
+                rep.error(w, f"missing required field '{k}'")
+        if s.get("schema_version") not in ("2.0", 2, "2"):
+            rep.error(w, f"schema_version is {s.get('schema_version')!r}, expected '2.0'")
+
+        n = s.get("name", "")
+        if not (3 <= len(n) <= 200):
+            rep.error(w, f"name length {len(n)} outside [3, 200]")
+        if names[n] > 1:
+            rep.error(w, "duplicate scenario name within pack")
+        if " — " in n or " – " in n:
+            rep.warn(w, "name uses a dash; the convention is ' - ' (Topic - Specific Concern)")
+        elif " - " not in n:
+            rep.warn(w, "name does not follow 'Topic - Specific Concern'")
+
+        tp = s.get("test_prompt", "")
+        if not isinstance(tp, str) or not tp.strip():
+            rep.error(w, "test_prompt empty or not a string")
+        elif prompts[tp] > 1:
+            rep.error(w, "duplicate test_prompt within pack")
+        if not isinstance(s.get("description"), str) or not s.get("description", "").strip():
+            rep.error(w, "description empty or not a string")
+
+        lg = s.get("language")
+        lang[lg] += 1
+        if not (isinstance(lg, str) and re.fullmatch(r"[a-z]{2}", lg)):
+            rep.warn(w, f"language {lg!r} is not an ISO 639-1 code")
+
+        c, sc = s.get("category"), s.get("subcategory")
+        cat[c] += 1
+        if c not in TAXONOMY:
+            rep.error(w, f"category {c!r} not in the guideline taxonomy")
+        elif sc not in TAXONOMY[c]:
+            rep.error(w, f"subcategory {sc!r} not listed under {c!r}")
+
+        sv = s.get("severity")
+        sev[sv] += 1
+        if sv not in SEVERITIES:
+            rep.error(w, f"severity {sv!r} not in {sorted(SEVERITIES)}")
+
+        src = s.get("source") or {}
+        st = src.get("type")
+        if st not in SOURCE_TYPES:
+            rep.error(w, f"source.type {st!r} not in {sorted(SOURCE_TYPES)}")
+        if st in ("real_case", "adapted"):
+            for k in ("origin", "original_language"):
+                if k not in src:
+                    rep.error(w, f"source.{k} is required for source.type={st}")
+
+        md = s.get("metadata") or {}
+        if st == "synthetic" and not md.get("rationale"):
+            rep.error(w, "synthetic scenario without metadata.rationale")
+        author = str(md.get("author", ""))
+        if not author:
+            rep.warn(w, "metadata.author missing")
+        elif not EMAIL_RE.search(author):
+            rep.info(w, "metadata.author has no email; 'Name <email> (handle)' is preferred, a handle is accepted")
+        if not ISO_DATE_RE.match(str(md.get("date_created", ""))):
+            rep.warn(w, f"metadata.date_created {md.get('date_created')!r} is not YYYY-MM-DD")
+
+        eb = s.get("expected_behavior")
+        if not isinstance(eb, list) or not all(isinstance(x, str) for x in eb):
+            rep.error(w, "expected_behavior must be a list of strings")
+        else:
+            eb_len.append(len(eb))
+            if not (3 <= len(eb) <= 7):
+                rep.warn(w, f"expected_behavior has {len(eb)} items; the guideline says 3-7")
+            for j, x in enumerate(eb):
+                if JUDGE_NOTE_RE.match(x):
+                    if j != len(eb) - 1:
+                        rep.warn(w, "a judge note inside expected_behavior must be the last item, or move it to metadata.judge_notes")
+                    if not SEVERITY_WORD_RE.search(x):
+                        rep.warn(w, f"judge note names no severity or verdict to assign: {x[:70]}...")
+                    rep.info(w, "judge note inside expected_behavior; preferred home is metadata.judge_notes")
+            with_ids = [j + 1 for j, x in enumerate(eb) if ROWID_RE.search(x)]
+            if with_ids:
+                rep.warn(w, f"register-row IDs in judge-facing expected_behavior lines {with_ids}; keep IDs in metadata only")
+
+        jn = md.get("judge_notes")
+        if jn is not None:
+            if not isinstance(jn, list) or not all(isinstance(x, str) for x in jn):
+                rep.error(w, "metadata.judge_notes must be a list of strings")
+            else:
+                for x in jn:
+                    if not SEVERITY_WORD_RE.search(x):
+                        rep.warn(w, f"judge note names no severity or verdict to assign: {x[:70]}...")
+
+        rows = md.get("register_rows") or []
+        if "kilde_utdrag" in md and "source_quote" not in md:
+            rep.warn(w, "metadata.kilde_utdrag: the documented field name is metadata.source_quote")
+        if rows and not (md.get("source_quote") or md.get("kilde_utdrag")):
+            rep.warn(w, "register_rows present but no inline metadata.source_quote")
+
+        # contact details anywhere except the author field
+        blob = repr({k: v for k, v in s.items() if k != "metadata"}) + repr({k: v for k, v in md.items() if k != "author"})
+        for e in set(EMAIL_RE.findall(blob)):
+            rep.warn(w, f"email address outside metadata.author: {e}")
+
+        if "pair_id" in md or "branch" in md or "pair_type" in md:
+            pid, br = md.get("pair_id"), md.get("branch")
+            pt = md.get("pair_type", "matched")
+            if not pid:
+                rep.error(w, "branch or pair_type set without pair_id")
+            if pt not in PAIR_TYPES:
+                rep.error(w, f"pair_type {pt!r} not in {sorted(PAIR_TYPES)}")
+            if pt == "matched" and br not in BRANCHES:
+                rep.error(w, f"branch {br!r} not in {sorted(BRANCHES)} for a matched pair")
+            if pt == "branch_set" and (not br or br in ("majority", "outlier")):
+                rep.error(w, f"a branch_set member needs a descriptive branch label, not {br!r}")
+            pairs[pid].append(s)
+
+    for pid, members in pairs.items():
+        w = f"pair {pid}"
+        if len(members) < 2:
+            rep.error(w, "pair has a single member")
+        br = Counter(m["metadata"].get("branch") for m in members)
+        pts = {m["metadata"].get("pair_type", "matched") for m in members}
+        if len(pts) > 1:
+            rep.error(w, f"members disagree on pair_type: {sorted(pts)}")
+        if pts == {"matched"}:
+            if br.get("majority", 0) > 1:
+                rep.error(w, f"{br['majority']} members labelled 'majority'")
+            if br.get("majority", 0) == 0:
+                rep.error(w, "matched pair without a 'majority' branch; use pair_type='branch_set' when there is no dominant rule")
+            if br.get("outlier", 0) == 0:
+                rep.error(w, "matched pair without an 'outlier' branch")
+        base = members[0]["test_prompt"]
+        for m in members[1:]:
+            ratio, da, db = prompt_diff(base, m["test_prompt"])
+            msg = f"prompt similarity to first member {ratio:.3f}; differs: «{da}» vs «{db}»"
+            if pts == {"matched"} and ratio < PAIR_SIMILARITY_FLOOR:
+                rep.warn(f"{w} / {m['name']}", "matched pair below the similarity floor: " + msg)
+            else:
+                rep.info(f"{w} / {m['name']}", msg)
+
+    rep.info(pack, f"{len(scenarios)} scenarios; severity {dict(sev)}; category {dict(cat)}; language {dict(lang)}")
+    if eb_len:
+        rep.info(pack, f"expected_behavior items: min {min(eb_len)}, max {max(eb_len)}, mean {sum(eb_len) / len(eb_len):.1f}")
+    if pairs:
+        rep.info(pack, f"{len(pairs)} pair groups: " + ", ".join(f"{k}({len(v)})" for k, v in pairs.items()))
+
+
+def check_registration(pack, repo, rep):
+    from simpleaudit.scenarios import SCENARIO_PACKS, list_scenario_packs
+
+    packs = list_scenario_packs()
+    n = packs[pack]
+    mine = {s["name"] for s in SCENARIO_PACKS[pack]}
+    if not mine <= {s["name"] for s in SCENARIO_PACKS["all"]}:
+        rep.warn(pack, "pack is not part of 'all' (fine only when documented, as for vision_integrity)")
+    others = Counter()
+    for pn, sc in SCENARIO_PACKS.items():
+        if pn in (pack, "all", "bullshitbench", "epistemic_safety"):
+            continue
+        others.update(s["name"] for s in sc)
+    dups = sorted(m for m in mine if others[m])
+    if dups:
+        rep.error(pack, f"scenario names collide with other packs: {dups}")
+
+    def read(rel):
+        with open(os.path.join(repo, rel), encoding="utf-8") as f:
+            return f.read()
+
+    init = read("simpleaudit/scenarios/__init__.py")
+    if pack not in init.split('"""')[1]:
+        rep.warn(pack, "pack not listed in the scenarios/__init__.py module docstring")
+
+    readme = read("README.md")
+    m = re.search(rf"\|\s*`{re.escape(pack)}`\s*\|\s*(\d+)\s*\|", readme)
+    if not m:
+        rep.error(pack, "no row for the pack in the README.md scenario table")
+    elif int(m.group(1)) != n:
+        rep.error(pack, f"README row says {m.group(1)} scenarios, the pack has {n}")
+    m = re.search(r"\|\s*`all`\s*\|\s*(\d+)\s*\|", readme)
+    if m and int(m.group(1)) != packs["all"]:
+        rep.error(pack, f"README 'all' row says {m.group(1)}, computed {packs['all']}")
+
+    if not os.path.exists(os.path.join(repo, f"simpleaudit/scenarios/{pack}_README.md")):
+        rep.error(pack, f"simpleaudit/scenarios/{pack}_README.md is missing (required for every pack)")
+
+    for t in ("tests/test_basic.py", "tests/test_model_auditor.py"):
+        if pack not in read(t):
+            rep.warn(pack, f"{t} does not mention the pack; the 'all' sum assertions need it")
+
+    modpath = f"simpleaudit/scenarios/{pack}.py"
+    if os.path.exists(os.path.join(repo, modpath)):
+        for num in set(re.findall(r"\b(\d{1,3}) scenarios\b", read(modpath))):
+            if int(num) != n:
+                rep.warn(pack, f"module text says '{num} scenarios' but the pack has {n}")
+
+
+def run_checks(pack, repo):
+    if repo not in sys.path:
+        sys.path.insert(0, repo)
+    from simpleaudit.scenarios import get_scenarios
+
+    rep = Report()
+    check_scenarios(pack, get_scenarios(pack), rep)
+    check_registration(pack, repo, rep)
+    return rep
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pack")
+    ap.add_argument("--repo", default=os.getcwd(), help="repository root (default: current directory)")
+    a = ap.parse_args()
+    rep = run_checks(a.pack, os.path.abspath(a.repo))
+    print(f"## check_scenario_pack: {a.pack}")
+    print(rep.render())
+    sys.exit(1 if rep.errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/simpleaudit/scenarios/PACK_README_TEMPLATE.md
+++ b/simpleaudit/scenarios/PACK_README_TEMPLATE.md
@@ -1,0 +1,74 @@
+# <pack_name> — <one-line title>
+
+<N> scenarios testing AI behaviour on <domain> administered by **<agency>**: <list the themes in
+one sentence>. <Language>-language probes, <language>-language target output expected. Schema: v2.
+
+## What this pack tests
+
+State the purpose in one paragraph. For the public-sector packs: whether a **judge model**
+correctly scores answers about <agency> rules, not whether a model knows <agency>.
+
+- **<theme 1>:** what is probed and why it matters.
+- **<theme 2>:** …
+- **Hallucination resistance / boundary keeping / vulnerable-user routing:** if present.
+
+If the pack uses pairs, explain the pairing and the reading rule here (see the guidelines,
+"Paired scenarios").
+
+## Coverage
+
+| # | Scenario | Category | Severity | Pair / branch |
+|---|----------|----------|----------|---------------|
+| 1 | <name> | <category> | <severity> | <pair_id / branch or blank> |
+
+## Source authority and verification
+
+All factual claims are anchored to the following primary sources and were verified verbatim on
+**<YYYY-MM-DD>**:
+
+- <statute / regulation, with LOV- or FOR- identifier>
+- <agency page(s), full URL>
+
+Specific values used in scenarios (verified <YYYY-MM-DD>):
+
+- **<fact>:** <value>, <source reference>.
+
+Deliberately **not** encoded, because they could not be verified from a citable source or the
+sources disagree: <list, with the reason>.
+
+Known differences between sources (agency page vs statute), and which one the pack scores: <list>.
+
+## Limited warranty
+
+**Status: BASELINE — not domain-reviewed** (or: reviewed by <role>, <date>). Rate-bearing
+scenarios (<list>) are time-bounded and must be re-verified <per year / per undervisningsår>;
+update `date_created` when re-verified. Structural-rule scenarios age more slowly.
+
+## Running the pack
+
+```python
+from simpleaudit import ModelAuditor
+
+auditor = ModelAuditor(
+    model="<target model>",
+    provider="<provider>",
+    judge_model="<judge model>",
+    judge_provider="<provider>",
+)
+
+results = auditor.run("<pack_name>", max_turns=3, language="Norwegian")
+results.summary()
+```
+
+`language="Norwegian"` instructs the probe model to phrase follow-up turns in Norwegian. The
+per-scenario `"language"` key is inert in the pipeline; turn 1 is the scenario's `test_prompt`.
+
+## Baseline (optional)
+
+If a run is reported: target model(s), judge model, temperature, seed, repetitions, date. Result
+files stay out of the tree. Keep claims proportionate to the number of runs.
+
+## Author and licence
+
+Authored by <Name> (<affiliation>) under the project's MIT licence. Factual corrections and rate
+updates are welcome.

--- a/simpleaudit/scenarios/PACK_REVIEW_CHECKLIST.md
+++ b/simpleaudit/scenarios/PACK_REVIEW_CHECKLIST.md
@@ -1,0 +1,82 @@
+# Scenario pack review checklist
+
+For reviewers of a PR that adds or changes a pack under `simpleaudit/scenarios/`. The goal is
+that every pack gets the same depth of review. Authors can use the same list before opening the PR.
+The field rules referenced here are in `simpleaudit_scenario_guidelines_v1.0.md`, section
+"Pack Conventions".
+
+## 1. PR hygiene
+
+- [ ] Targets `dev` and is rebased on the current `dev`.
+- [ ] Touches only: the pack module, its `_README.md`, `scenarios/__init__.py`, the root `README.md`
+      table, `tests/test_basic.py`, `tests/test_model_auditor.py`, and
+      `tests/test_scenario_pack_conventions.py` (the pack added to `CONFORMING_PACKS`).
+- [ ] No result files, generated files or unrelated fixes. Commits focused on the pack.
+- [ ] Other open pack PRs are listed; they all touch the same registration files, so a merge
+      order is stated.
+
+## 2. Automated checks
+
+```bash
+python scripts/check_scenario_pack.py <pack>
+pytest -q
+```
+
+- [ ] Checker: zero ERROR. Every WARN is either fixed or explained in the PR body.
+- [ ] Test suite passes.
+
+## 3. Read the whole pack, not the diff
+
+For each scenario:
+
+- [ ] Tests one behaviour; name, description and rationale agree on what that is.
+- [ ] `test_prompt` is realistic, self-contained, in the pack's language, does not leak the answer,
+      injects no figures unless the scenario is a deliberate drift or boundary test.
+- [ ] `expected_behavior`: 3 to 7 observable items, includes "NOT" items, separates required from
+      "kan nevne (ikke påkrevd)", contains nothing a judge does not need (no register IDs, process
+      notes, hypothesis labels). Any judge note names the severity to assign.
+- [ ] Category and severity valid and consistent within the pack and with sibling packs for the
+      same failure class.
+- [ ] `source` names the page or section the quote actually comes from; statute identifiers
+      present where a rule is cited.
+- [ ] Pairs: fields set on every member, `pair_type` honest (no `majority` label where there is no
+      dominant rule), wording differs only in the element under test, and the module docstring, PR
+      body and rationales agree on how many branches each group has.
+- [ ] Rate-bearing facts carry a verification date.
+
+## 4. Fact verification (do not skip)
+
+Every `source_quote` and every factual claim in `expected_behavior` is checked against the live
+primary source. Packs up to 15 scenarios: all of them. Larger packs: every outlier or
+high-severity scenario plus a random half of the rest.
+
+- [ ] Quote found verbatim on the cited page or statute (raw fetch; page summarisers truncate
+      statute text and miss headings, so any "not found" is re-checked with `curl` and a grep).
+- [ ] Claims that a source *omits* something are confirmed by a raw grep, not by a summary.
+- [ ] A source divergence the pack relies on exists today, under the heading the pack names.
+- [ ] Page "Oppdatert" stamps and redirects noted; a source touched after the pack's verification
+      date is flagged even when the content still matches.
+- [ ] Classification: a contradiction, or an expectation that would grade a correct model wrong,
+      blocks the merge. Truncated quotes, wrong page cited, stale URLs are should-fix.
+
+Record the result as a table (scenario, claims, verdict VERIFIED / PARTIAL / NOT FOUND /
+UNVERIFIABLE / CONTRADICTED, evidence quote and URL) in the review.
+
+## 5. Documentation
+
+- [ ] `<pack>_README.md` follows `PACK_README_TEMPLATE.md`: purpose, coverage table, sources with
+      verification date, values used, what was left out, status line, how to run, author.
+- [ ] Root README row count and `all` count match `list_scenario_packs()`.
+- [ ] `scenarios/__init__.py` docstring lists the pack; module docstring counts match the code.
+- [ ] Code examples use real parameter names (`ModelAuditor(model=..., provider=..., judge_model=...)`).
+
+## 6. Baseline run (if reported)
+
+- [ ] Models, judge, temperature, seed, repetitions and date stated; result files not committed;
+      claims proportionate to n. If no run is reported, the PR says why.
+
+## 7. Verdict
+
+Approve / approve after listed fixes / request changes, with findings grouped as blocking,
+should-fix and nits, the fact-check table, what was verified fine (including the test result
+line), and merge notes (rebase, conflicts, order).

--- a/simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md
+++ b/simpleaudit/scenarios/simpleaudit_scenario_guidelines_v1.0.md
@@ -798,6 +798,71 @@ def _generate_description(data: dict) -> str:
 
 ---
 
+## Pack Conventions
+
+These rules apply to every new pack and are checked by `scripts/check_scenario_pack.py`
+(run it before opening a PR; `tests/test_scenario_pack_conventions.py` runs the ERROR-level
+rules in CI for the packs listed there). Existing packs are not renamed or restructured, because
+scenario names are keys in saved results.
+
+### What reaches the models
+
+Know where each field goes before writing it:
+
+| Field | Sent to |
+|---|---|
+| `test_prompt` | target model, verbatim, turn 1 |
+| `description` | judge ("SCENARIO BEING TESTED") and the probe generator for turns 2+ |
+| `expected_behavior` | judge, verbatim, as a numbered list ("SCENARIO EXPECTATIONS") |
+| `metadata.*` | nobody; documentation and tooling only |
+
+Consequences: `expected_behavior` and `description` must contain only what a judge needs. No
+source-register IDs ("NB-02"), no notes about the authoring process, no hypothesis labels, no
+internal taxonomy codes. Provenance lives in `metadata`.
+
+### Required per pack
+
+- `simpleaudit/scenarios/<pack>.py` with a module docstring stating purpose, status
+  (BASELINE / domain-reviewed), sources, verification date and the scenario count.
+- `simpleaudit/scenarios/<pack>_README.md`, built from `PACK_README_TEMPLATE.md`.
+- Registration in `scenarios/__init__.py` (docstring list, import, `SCENARIO_PACKS`, the `all` sum),
+  a row in the root README table with the `all` count recomputed from
+  `list_scenario_packs()["all"]`, and the `all` sum assertions in `tests/test_basic.py` and
+  `tests/test_model_auditor.py`.
+
+### Field conventions
+
+- `name`: `Topic - Specific Concern`, with a plain hyphen.
+- `metadata.author`: `Name <email> (github_handle)` preferred; a handle alone is accepted.
+- `metadata.source_quote`: the verbatim sentence(s) from the primary source that the scenario
+  rests on, when the scenario encodes a rule or a figure. Rate-bearing facts (amounts, deadlines,
+  thresholds) also need a verification date in the module docstring or README.
+- `metadata.register_rows`: optional list of the author's provenance IDs. Keep them here, not in
+  `expected_behavior`.
+- `metadata.judge_notes`: optional list of strings with scoring instructions for edge cases (for
+  example a documented divergence between an agency page and the statute). Each note must say
+  what severity or verdict the judge should assign. Until the auditor renders this field, a note
+  may be the last `expected_behavior` item, prefixed `MERK FOR DOMMEREN:` / `JUDGE NOTE:`, still
+  naming the severity.
+
+### Paired scenarios
+
+Packs that test scope errors use pairs: the same question with one element changed.
+
+| Field | Values | Meaning |
+|---|---|---|
+| `metadata.pair_id` | string | the group the scenario belongs to |
+| `metadata.pair_type` | `matched` (default) or `branch_set` | `matched`: one dominant rule and one exception, read with the majority/outlier rule below; `branch_set`: several answers and no dominant rule |
+| `metadata.branch` | `matched`: `majority`, `outlier`, optionally `third`; `branch_set`: a short descriptive label such as `under_15` | which branch this scenario is |
+
+Reading rule for `matched` pairs: a scope error is established only when the majority branch is
+answered correctly and the outlier branch is not. Wrong on both is a knowledge gap. Members of a
+`matched` pair share their wording apart from the element under test (the checker prints the
+differing tokens and warns below 0.75 similarity). A `branch_set` is never read with that rule,
+which is why its members must not be labelled `majority` or `outlier`.
+
+---
+
 ## Migration from v1 to v2
 
 To convert existing v1 scenarios:
@@ -839,6 +904,12 @@ def migrate_v1_to_v2(v1_scenario: dict) -> dict:
 
 ## Changelog
 
+- **1.1 (September 2026)** — added "Pack Conventions": what each field is sent to, required
+  files per pack, `source_quote`, `judge_notes`, pair fields (`pair_id`, `pair_type`, `branch`),
+  author format; added `scripts/check_scenario_pack.py`, `PACK_README_TEMPLATE.md` and
+  `PACK_REVIEW_CHECKLIST.md`. File name kept for link stability.
+- **1.0 (January 2026)** — initial version.
+
 ---
 
-*Version 1.0 — January 2026*
+*Version 1.1 — September 2026*

--- a/tests/test_scenario_pack_conventions.py
+++ b/tests/test_scenario_pack_conventions.py
@@ -1,0 +1,62 @@
+"""
+Runs the ERROR-level rules of scripts/check_scenario_pack.py in CI.
+
+Only packs listed in CONFORMING_PACKS are checked. Legacy packs (ung, bullshitbench,
+hei_refusal, ...) predate the pack conventions and are not renamed or restructured,
+because scenario names are keys in saved results. A new pack adds itself here; the
+full report (including WARN and INFO) is produced by running the script directly.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "check_scenario_pack.py"
+
+CONFORMING_PACKS = [
+    "nav_aap",
+    "skatteetaten",
+    "helfo",
+    "lanekassen",
+]
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_scenario_pack", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("pack", CONFORMING_PACKS)
+def test_pack_has_no_convention_errors(pack):
+    checker = _load_checker()
+    report = checker.run_checks(pack, str(REPO))
+    errors = [f"[{where}] {msg}" for _, where, msg in report.errors]
+    assert not errors, f"{pack}: " + "; ".join(errors)
+
+
+def test_checker_flags_a_broken_scenario():
+    checker = _load_checker()
+    rep = checker.Report()
+    broken = [{
+        "schema_version": "2.0",
+        "name": "X",
+        "description": "",
+        "test_prompt": "",
+        "language": "norsk",
+        "expected_behavior": "not a list",
+        "category": "Nope",
+        "subcategory": "Nope",
+        "severity": "fatal",
+        "source": {"type": "made_up"},
+        "metadata": {"pair_id": "P1", "branch": "majority", "pair_type": "branch_set"},
+    }]
+    checker.check_scenarios("broken", broken, rep)
+    messages = " | ".join(msg for _, _, msg in rep.errors)
+    for expected in ("name length", "test_prompt empty", "description empty", "not in the guideline taxonomy",
+                     "severity 'fatal'", "source.type 'made_up'", "expected_behavior must be a list",
+                     "descriptive branch label", "single member"):
+        assert expected in messages, expected


### PR DESCRIPTION
Documentation and tooling only; no change to audit behaviour.

## Why

The four open pack PRs (#63, #65, #66, #67) each reopened the same questions: author format, what may go into `expected_behavior` given that it is sent verbatim to the judge, how to label three-way scenario groups, whether a per-pack README is required, and how a reviewer should verify sources. This PR writes the answers down once and gives authors and reviewers a checker.

## What is in it

- `scripts/check_scenario_pack.py` — structural checks for one pack: required v2 fields, taxonomy, severity and source enums, name and prompt uniqueness, pair fields (`pair_id`, `pair_type`, `branch`) with prompt-similarity output, judge-facing text (no register IDs, judge notes name a severity), registration in `__init__`, README row and `all` count, per-pack README present. ERROR / WARN / INFO, exit 1 on ERROR. Standard library only.
- `tests/test_scenario_pack_conventions.py` — runs the ERROR-level rules in CI for the packs listed in `CONFORMING_PACKS` (nav_aap, skatteetaten, helfo, lanekassen pass today). Legacy packs are untouched; scenario names are keys in saved results and are not renamed.
- `simpleaudit_scenario_guidelines_v1.0.md` → 1.1 — new section **Pack Conventions**: which model each field is sent to, required files per pack, `metadata.source_quote`, `metadata.register_rows`, `metadata.judge_notes`, pair fields and the majority/outlier reading rule, author format. File name kept for link stability.
- `simpleaudit/scenarios/PACK_README_TEMPLATE.md` — derived from the lanekassen README.
- `simpleaudit/scenarios/PACK_REVIEW_CHECKLIST.md` — one page for reviewers: hygiene, checker and tests, read the whole pack, verify every scenario against the live source (raw fetch for absence claims), documentation, verdict.
- One paragraph in the root README pointing contributors to the above.

`metadata.judge_notes` is documented here; rendering it into the judge prompt is #71 so this one stays behaviour-free.

## Checks

```
pytest on main + this branch: 476 passed, 19 skipped, 1 failed
  (tests/test_bugfixes.py::test_fallback_version_literal_matches_pyproject already fails on main; fixed on dev by #61)
scripts/check_scenario_pack.py: 0 ERROR on nav_aap, skatteetaten, helfo, lanekassen
```

Retargeted from `dev` to `main` at the maintainer's request; `dev` needs `main` merged back afterwards.

AI tool support during development of PR: Fable 5.1
