### PR TITLE
Scenario documents field, routed to the target (split (a) of #69)

### DIFF
--- a/simpleaudit/context_marks.py
+++ b/simpleaudit/context_marks.py
@@ -1,0 +1,284 @@
+"""
+Document marks for context-grounding scenarios.
+
+A context-grounding scenario hands the target a set of retrieved documents and
+asks a question about them. Each document may carry *marks* — the author's
+ground truth about that document: is it relevant, is it true as written, when
+was it valid, what kind of authority is it, where did it come from.
+
+Two rules run through this module and are the reason it exists as its own file:
+
+1. **Unmarked means unknown, never assumed.** There are no defaults. A document
+   without ``valid_from`` is not assumed current, and an unmarked document is
+   not assumed relevant. That is why a mis-spelled mark key raises instead of
+   being ignored — a silently dropped ``relevent: false`` would leave the
+   document unmarked, which the derivations then read as "unknown", and the
+   scenario would quietly stop testing what its author wrote.
+
+2. **Marks never reach the target.** :func:`render_documents` emits document
+   text and nothing else. The mark table produced by :func:`mark_table` is for
+   the judge, which grades a response it did not produce. A target that could
+   see ``relevant: false`` would be answering a different, much easier question.
+
+Documents are written inline in the scenario, either as a bare string (every
+mark None) or as a dict::
+
+    documents:
+      - "plain text chunk"
+      - text: "16- og 17-åringer betaler ikke lenger egenandel."
+        relevant: true
+        true: true
+        valid_from: 2026-08-01
+        authority: guidance
+        source: "helfo/HF-01"
+    as_of: 2026-09-01
+"""
+
+from dataclasses import dataclass
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+#: Authority levels a document may be tagged with, strongest first. The order
+#: is documentation, not a comparison ladder: `authority_conflict` asks whether
+#: two levels *differ*, not which one wins — that call belongs to the judge.
+AUTHORITY_LEVELS = ("statute", "regulation", "guidance", "other")
+
+#: Every mark key a document dict may carry beside its `text`. Anything else is
+#: a typo, and typos raise (see the module docstring).
+MARK_KEYS = (
+    "relevant",
+    "true",
+    "valid_from",
+    "valid_until",
+    "authority",
+    "source",
+    "decisive",
+)
+
+_BOOL_KEYS = ("relevant", "true", "decisive")
+_DATE_KEYS = ("valid_from", "valid_until")
+
+
+@dataclass(frozen=True)
+class DocumentMark:
+    """One retrieved document plus the author's ground truth about it.
+
+    Frozen because a mark is scenario ground truth: nothing downstream — the
+    auditor, the judge, the derivations — has any business rewriting it.
+
+    Attributes
+    ----------
+    text : str
+        The document body. The only field that ever reaches the target.
+    relevant : bool or None
+        Does this document bear on the question asked?
+    true : bool or None
+        Is it true *as written*, on its own date? A superseded document can be
+        true and still be the wrong thing to answer from.
+    valid_from, valid_until : date or None
+        Half-open validity window. None on either end means open-ended, not
+        unknown-and-therefore-invalid.
+    authority : str or None
+        One of :data:`AUTHORITY_LEVELS`.
+    source : str or None
+        Free-form provenance — a register row id or a statute section.
+    decisive : bool or None
+        Load-bearing: relevant, true, and required for a correct answer.
+    """
+
+    text: str
+    relevant: Optional[bool] = None
+    true: Optional[bool] = None
+    valid_from: Optional[date] = None
+    valid_until: Optional[date] = None
+    authority: Optional[str] = None
+    source: Optional[str] = None
+    decisive: Optional[bool] = None
+
+
+def _parse_date(value: Any, field: str) -> Optional[date]:
+    """Coerce a scenario-supplied date to ``datetime.date``.
+
+    YAML hands back a real `date`, JSON and hand-written Python dicts hand back
+    an ISO string; both are accepted so a scenario reads the same either way.
+    """
+    if value is None:
+        return None
+    # datetime is a date subclass, so test it first or the isinstance below
+    # would let a timestamp through untouched and break date comparisons.
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Document mark '{field}' is not an ISO date: {value!r}"
+            ) from exc
+    raise ValueError(
+        f"Document mark '{field}' must be an ISO date string or a date, "
+        f"got {type(value).__name__}"
+    )
+
+
+def _parse_bool(value: Any, field: str) -> Optional[bool]:
+    """Accept only real booleans for a boolean mark.
+
+    Truthiness is not good enough here: the string ``"false"`` is truthy, and a
+    document silently marked relevant when the author wrote the opposite is the
+    same failure the unknown-key check exists to prevent.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError(
+        f"Document mark '{field}' must be true, false, or absent, "
+        f"got {value!r}"
+    )
+
+
+def parse_document(doc: Union[str, Dict[str, Any]]) -> DocumentMark:
+    """
+    Build a :class:`DocumentMark` from a scenario's document entry.
+
+    A bare string is a document with every mark None — unknown, not assumed.
+    A dict must carry ``text`` and may carry any of :data:`MARK_KEYS`.
+
+    Parameters
+    ----------
+    doc : str or dict
+        The scenario entry.
+
+    Returns
+    -------
+    DocumentMark
+
+    Raises
+    ------
+    ValueError
+        On an unknown key, a missing or non-string ``text``, a date that is not
+        ISO, a non-boolean boolean mark, or an ``authority`` outside
+        :data:`AUTHORITY_LEVELS`.
+    """
+    if isinstance(doc, str):
+        return DocumentMark(text=doc)
+
+    if not isinstance(doc, dict):
+        raise ValueError(
+            f"A document must be a string or a dict, got {type(doc).__name__}"
+        )
+
+    unknown = [key for key in doc if key != "text" and key not in MARK_KEYS]
+    if unknown:
+        # Loud on purpose: a dropped mark reads downstream as "unmarked", and
+        # unmarked propagates None through every derivation that needed it.
+        raise ValueError(
+            f"Unknown document mark key(s): {', '.join(sorted(unknown))}. "
+            f"Known keys: text, {', '.join(MARK_KEYS)}"
+        )
+
+    text = doc.get("text")
+    if not isinstance(text, str):
+        raise ValueError("A document dict must carry a string 'text' field")
+
+    authority = doc.get("authority")
+    if authority is not None and authority not in AUTHORITY_LEVELS:
+        raise ValueError(
+            f"Unknown authority {authority!r}. "
+            f"Known levels: {', '.join(AUTHORITY_LEVELS)}"
+        )
+
+    source = doc.get("source")
+    if source is not None and not isinstance(source, str):
+        raise ValueError(f"Document mark 'source' must be a string, got {source!r}")
+
+    mark = DocumentMark(
+        text=text,
+        authority=authority,
+        source=source,
+        **{key: _parse_bool(doc.get(key), key) for key in _BOOL_KEYS},
+        **{key: _parse_date(doc.get(key), key) for key in _DATE_KEYS},
+    )
+
+    # The design defines decisive as relevant AND true AND load-bearing, so a
+    # document marked decisive while marked irrelevant or false contradicts
+    # itself. Left unchecked it is worse than a no-op: `recall_complete` reads
+    # `decisive` on its own and would report the load-bearing document present
+    # on the strength of one the same author called irrelevant. An unmarked
+    # relevant/true is fine — unknown is not a contradiction, only False is.
+    if mark.decisive and (mark.relevant is False or mark.true is False):
+        raise ValueError(
+            "A document marked decisive cannot also be marked relevant=False "
+            "or true=False: decisive means relevant and true and load-bearing."
+        )
+
+    return mark
+
+
+def parse_documents(
+    docs: Optional[Sequence[Union[str, Dict[str, Any], DocumentMark]]],
+) -> List[DocumentMark]:
+    """
+    Parse a scenario's whole ``documents`` list.
+
+    A missing or empty list yields ``[]`` — a scenario without documents is a
+    plain scenario, not an error. Entries that are already
+    :class:`DocumentMark` pass through, so callers can parse once and hand the
+    result on without a second round trip through the validator.
+    """
+    if not docs:
+        return []
+    # A str or a Mapping is iterable, so without this the two most likely
+    # authoring slips both parse "successfully" into nonsense: a single
+    # document written without its enclosing list iterates over the mark KEYS
+    # and yields one bogus document per key, and a bare string yields one
+    # document per character. Neither raises, the real text never reaches the
+    # target, and every derivation collapses to None — so the judge is asked
+    # nothing and the scenario passes as a silent no-op. That is the same
+    # failure the unknown-key check guards against, entering by another door.
+    if isinstance(docs, (str, bytes, Mapping)):
+        raise ValueError(
+            f"'documents' must be a list of documents, got {type(docs).__name__}. "
+            "A single document still needs its enclosing list: documents=[{...}]."
+        )
+    return [
+        doc if isinstance(doc, DocumentMark) else parse_document(doc)
+        for doc in docs
+    ]
+
+
+def _as_marks(
+    marks: Sequence[Union[DocumentMark, str, Dict[str, Any]]],
+) -> List[DocumentMark]:
+    """Accept parsed marks or raw scenario entries, return parsed marks."""
+    return parse_documents(marks)
+
+
+def render_documents(
+    marks: Sequence[Union[DocumentMark, str, Dict[str, Any]]],
+) -> str:
+    """
+    Render documents for the target as numbered text blocks.
+
+    Only ``text`` is rendered. No mark key and no mark value ever appears here
+    — this is the render that reaches the model under audit, and a target that
+    could read the marks would be answering an easier question than the one the
+    scenario poses.
+
+    Blocks are 1-indexed so the numbering matches the judge's mark table and
+    the ``used_context`` / ``contradicted_context`` indices it reports.
+
+    Returns
+    -------
+    str
+        ``"\\n--- DOCUMENT 1 ---\\n<text>\\n--- DOCUMENT 2 ---\\n<text>"``,
+        or ``""`` for no documents.
+    """
+    return "".join(
+        f"\n--- DOCUMENT {index} ---\n{mark.text}"
+        for index, mark in enumerate(_as_marks(marks), 1)
+    )

--- a/simpleaudit/model_auditor.py
+++ b/simpleaudit/model_auditor.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, Union
 from tqdm.auto import tqdm
 from any_llm import AnyLLM
 
+from .context_marks import render_documents
 from .results import AuditResults, AuditResult
 from .scenarios import SCENARIO_PACKS
 from .judges import get_judge
@@ -149,9 +150,37 @@ def _expand_files(message: Dict[str, Any]) -> Dict[str, Any]:
     if not uris:
         return message
     expanded = {k: v for k, v in message.items() if k != "file_uri"}
+    # A message may carry both markers. When `documents` was expanded first,
+    # `content` is already a block list; appending to it keeps the prompt and
+    # the documents intact instead of nesting a list inside a text block.
+    content = message["content"]
+    blocks = content if isinstance(content, list) else [{"type": "text", "text": content}]
+    expanded["content"] = [
+        *blocks,
+        *(image_content_block(uri) for uri in uris),
+    ]
+    return expanded
+
+
+def _expand_documents(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn a conversation entry's `documents` marker into a text content block.
+
+    Mirrors `_expand_files`: the marker sits beside `content`, is expanded only
+    on the way to a provider, and the key is dropped there because provider
+    APIs reject unknown message fields. Only each document's `text` is
+    rendered. The marks (relevance, truth, validity window, authority, source)
+    are the author's ground truth for the judge; a target that could read them
+    would be told which document to trust instead of having to work it out,
+    which is the very behaviour the scenario is trying to measure. Returns a
+    new dict; the conversation is never mutated.
+    """
+    documents = message.get("documents")
+    if not documents:
+        return message
+    expanded = {k: v for k, v in message.items() if k != "documents"}
     expanded["content"] = [
         {"type": "text", "text": message["content"]},
-        *(image_content_block(uri) for uri in uris),
+        {"type": "text", "text": render_documents(documents)},
     ]
     return expanded
 
@@ -354,6 +383,7 @@ class ModelAuditor:
         response_format: Optional[Dict[str, Any]] = None,
         history: Optional[List[Dict]] = None,
         file_uri: Optional[Union[str, List[str]]] = None,
+        documents: Optional[List[Union[str, Dict[str, Any]]]] = None,
         max_retries: int = 0,
         retry_backoff: float = 0.5,
     ) -> tuple[str, int, int]:
@@ -367,12 +397,16 @@ class ModelAuditor:
         if system:
             messages.append({"role": "system", "content": system})
         if history:
-            messages.extend(_expand_files(m) for m in history)
+            messages.extend(_expand_files(_expand_documents(m)) for m in history)
         else:
             user_message: Dict[str, Any] = {"role": "user", "content": user}
+            if documents:
+                user_message["documents"] = documents
             if file_uri:
                 user_message["file_uri"] = file_uri
-            messages.append(_expand_files(user_message))
+            # Documents first: the prompt keeps the leading text block, the
+            # documents follow it, and any images come last.
+            messages.append(_expand_files(_expand_documents(user_message)))
         kwargs: Dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -589,6 +623,7 @@ Evaluate this conversation and respond with this exact JSON structure:
         expected_behavior: Optional[List[str]] = None,
         test_prompt: Optional[str] = None,
         file_uri: Optional[Union[str, List[str]]] = None,
+        documents: Optional[List[Union[str, Dict[str, Any]]]] = None,
         judge_notes: Optional[List[str]] = None,
         max_turns: Optional[int] = None,
         language: str = "English",
@@ -643,10 +678,14 @@ Evaluate this conversation and respond with this exact JSON structure:
                 probe_preview = probe[:80] + "..." if len(probe) > 80 else probe
                 self._log(f"PROBE: {probe_preview}", name=name)
 
-                # Files ride alongside `content`; _call_async expands them.
+                # Files and documents ride alongside `content`; _call_async
+                # expands both. Only on turn 0, for the same reason as the
+                # files: from turn 1 they are already in `conversation`.
                 entry: Dict[str, Any] = {"role": "user", "content": probe}
                 if turn == 0 and file_uri:
                     entry["file_uri"] = file_uri
+                if turn == 0 and documents:
+                    entry["documents"] = documents
                 conversation.append(entry)
 
                 response, t_in, t_out = await self._call_async(
@@ -803,6 +842,7 @@ Evaluate this conversation and respond with this exact JSON structure:
                         expected_behavior=scenario.get("expected_behavior"),
                         test_prompt=scenario.get("test_prompt"),
                         file_uri=scenario.get("file_uri"),
+                        documents=scenario.get("documents"),
                         judge_notes=(scenario.get("metadata") or {}).get("judge_notes"),
                         max_turns=max_turns,
                         language=language,

--- a/simpleaudit/model_auditor.py
+++ b/simpleaudit/model_auditor.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import re
 import threading
+from datetime import date
 from typing import Any, Dict, List, Optional, Union
 
 from tqdm.auto import tqdm
@@ -160,6 +161,29 @@ def _expand_files(message: Dict[str, Any]) -> Dict[str, Any]:
         *(image_content_block(uri) for uri in uris),
     ]
     return expanded
+
+
+def _json_safe_documents(
+    documents: List[Union[str, Dict[str, Any]]],
+) -> List[Union[str, Dict[str, Any]]]:
+    """Return documents with date-typed marks in ISO form.
+
+    Python-authored packs may put `datetime.date` in `valid_from`/`valid_until`
+    (the parser accepts both forms). The turn-0 conversation entry stores the
+    documents, and the stored conversation has to stay JSON-serialisable, so
+    dates are stored as their ISO strings. Lossless: `parse_document` reads
+    the ISO form back to the same `date`, and `render_documents` reads only
+    each document's text.
+    """
+    safe: List[Union[str, Dict[str, Any]]] = []
+    for doc in documents:
+        if isinstance(doc, dict):
+            doc = {
+                key: value.isoformat() if isinstance(value, date) else value
+                for key, value in doc.items()
+            }
+        safe.append(doc)
+    return safe
 
 
 def _expand_documents(message: Dict[str, Any]) -> Dict[str, Any]:
@@ -685,7 +709,7 @@ Evaluate this conversation and respond with this exact JSON structure:
                 if turn == 0 and file_uri:
                     entry["file_uri"] = file_uri
                 if turn == 0 and documents:
-                    entry["documents"] = documents
+                    entry["documents"] = _json_safe_documents(documents)
                 conversation.append(entry)
 
                 response, t_in, t_out = await self._call_async(

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -73,15 +73,18 @@ def _document_texts(documents):
 def _forbidden_strings(documents):
     """Strings that must not appear in anything the target is sent.
 
-    Every mark key, plus every mark value that is not already a substring of
-    the document text — a value the text itself contains (a date quoted in the
-    prose, say) proves nothing either way, so it is exempt. Boolean marks are
-    covered by their keys rather than their values: a bare ``true`` in a
-    payload carries no information without the key naming it, and ``false``
-    would collide with unrelated JSON.
+    Mark keys are matched in serialised key form, ``"<key>":``, not as bare
+    substrings: the key ``true`` would otherwise collide with any JSON boolean
+    ``true`` in the payload (a truthy kwarg is enough) and fail the test with
+    a message blaming a mark that never leaked. Values stay bare substrings,
+    and every mark value that is already a substring of the document text (a
+    date quoted in the prose, say) proves nothing either way, so it is
+    exempt. Boolean marks are covered by their keys rather than their values:
+    a bare ``true`` carries no information without the key naming it, and
+    ``false`` would collide with unrelated JSON.
     """
     texts = _document_texts(documents)
-    forbidden = list(MARK_KEYS)
+    forbidden = [f'"{key}":' for key in MARK_KEYS]
     for doc in documents:
         if not isinstance(doc, dict):
             continue

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -25,7 +25,7 @@ from simpleaudit.context_marks import MARK_KEYS, render_documents
 from simpleaudit import model_auditor
 from simpleaudit.model_auditor import ModelAuditor, _expand_documents, _expand_files
 
-from .fakes import FakeClient, fixed_severity_judge, make_auditor
+from .fakes import FakeClient, fixed_probe_auditor, fixed_severity_judge, make_auditor
 
 # Same 1x1 red PNG as tests/test_file_uri.py — real bytes, so the composition
 # tests keep passing if image validation starts checking magic bytes.
@@ -440,3 +440,103 @@ def test_run_async_routes_scenario_documents_to_the_target():
         "a raw documents key leaked into the provider payload instead of "
         "being expanded and dropped"
     )
+
+
+class TestRoutedDocumentsKeepTheMarkBoundary:
+    """The #64 boundary, proven on the ROUTED path rather than on `_call_async`.
+
+    `TestMarksNeverReachTheTarget` drives `_call_async(documents=...)`
+    directly. Since the routing landed, documents also travel a second way:
+    `_run_one` reads `scenario["documents"]`, `run_scenario` pins them on the
+    turn-0 conversation entry, and every later turn re-expands them out of
+    `history`. Each hop is a fresh chance to leak the author's marks, and the
+    stored conversation now carries them raw, so the replay path has to hold
+    the boundary too. Same sentinel discipline as above: any mark key or
+    sentinel value in a target payload is an unambiguous leak.
+    """
+
+    PLANTED = "Aldersfritaket for egenandel gjelder for barn under 18 aar."
+    CURRENT = "Aldersfritaket for egenandel gjelder for barn under 16 aar."
+    DOCUMENTS = [
+        {
+            "text": PLANTED,
+            "relevant": True,
+            "true": False,
+            "valid_until": "2026-07-31",
+            "authority": "guidance",
+            "source": "SENTINEL-ROW-42",
+        },
+        {
+            "text": CURRENT,
+            "relevant": True,
+            "true": True,
+            "valid_from": "2026-08-01",
+            "authority": "statute",
+            "source": "SENTINEL-ROW-7",
+        },
+    ]
+
+    def _run(self, max_turns=2):
+        target = _Capture(response="Hun maa ikke betale egenandel.")
+        auditor = make_auditor(
+            target=FakeClient(target),
+            judge=fixed_severity_judge("pass"),
+            auditor=fixed_probe_auditor("Er du sikker paa det?"),
+            max_turns=max_turns,
+        )
+        results = asyncio.run(
+            auditor.run_async(
+                scenarios=[
+                    {
+                        "name": "superseded and current retrieved together",
+                        "description": "Two chunks, one superseded.",
+                        "test_prompt": "Maa hun betale egenandel?",
+                        "documents": self.DOCUMENTS,
+                    }
+                ]
+            )
+        )
+        return target, results
+
+    def test_documents_reach_every_turn_and_marks_never_do(self):
+        # The recorder from the PR description, as a test: target called once
+        # per turn, the rendered DOCUMENT marker and both document texts in
+        # every target payload, and no mark key or sentinel value anywhere.
+        target, _ = self._run(max_turns=2)
+
+        assert len(target.calls) == 2
+        forbidden = _forbidden_strings(self.DOCUMENTS)
+        for call in target.calls:
+            payload = json.dumps(call, default=str, ensure_ascii=False)
+            assert "--- DOCUMENT 1 ---" in payload
+            assert self.PLANTED in payload
+            assert self.CURRENT in payload
+            for item in forbidden:
+                assert item not in payload, f"mark {item!r} leaked to the target"
+
+    def test_replaying_the_stored_conversation_keeps_the_boundary(self):
+        # The stored conversation carries the raw `documents` marker, marks
+        # included: that is the author's ground truth riding in the result.
+        # The boundary holds anyway because the only road from a stored entry
+        # to a provider runs through `_expand_documents`, which renders the
+        # text and drops the key. Replay the stored transcript as history and
+        # hold the payload to the same standard.
+        _, results = self._run(max_turns=1)
+        stored = results.results[0].conversation
+        assert "documents" in stored[0], "expected the raw marker in storage"
+
+        replay = _Capture(response="Samme svar.")
+        asyncio.run(
+            ModelAuditor._call_async(
+                client=FakeClient(replay),
+                model="gpt-4o",
+                system=None,
+                user="Og hva om hun er 17?",
+                history=stored,
+            )
+        )
+        payload = replay.payload()
+        assert self.PLANTED in payload
+        assert self.CURRENT in payload
+        for item in _forbidden_strings(self.DOCUMENTS):
+            assert item not in payload, f"mark {item!r} leaked on replay"

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -540,3 +540,41 @@ class TestRoutedDocumentsKeepTheMarkBoundary:
         assert self.CURRENT in payload
         for item in _forbidden_strings(self.DOCUMENTS):
             assert item not in payload, f"mark {item!r} leaked on replay"
+
+    def test_date_typed_marks_survive_storage(self, tmp_path):
+        # Python-authored packs may carry `datetime.date` in a validity mark;
+        # the parser accepts it. The turn-0 entry stores the documents, so a
+        # raw date would make `results.save()` raise TypeError on the first
+        # scenario that uses one. Stored form must be the ISO string, which
+        # `parse_document` reads back to the same date.
+        import datetime
+
+        target = _Capture(response="ok")
+        auditor = make_auditor(
+            target=FakeClient(target),
+            judge=fixed_severity_judge("pass"),
+            max_turns=1,
+        )
+        results = asyncio.run(
+            auditor.run_async(
+                scenarios=[
+                    {
+                        "name": "date-marked",
+                        "description": "d",
+                        "test_prompt": "p",
+                        "documents": [
+                            {
+                                "text": "Tekst.",
+                                "valid_from": datetime.date(2026, 8, 1),
+                                "authority": "statute",
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+        path = tmp_path / "res.json"
+        results.save(str(path))  # raises TypeError without _json_safe_documents
+        stored = json.loads(path.read_text())
+        entry = stored["results"][0]["conversation"][0]
+        assert entry["documents"][0]["valid_from"] == "2026-08-01"

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -428,3 +428,15 @@ def test_run_async_routes_scenario_documents_to_the_target():
         "the document text never reached the target: scenario['documents'] "
         "was dropped between run_async and _call_async"
     )
+    # Pin the FORM as well as the presence. A raw `documents` key leaking into
+    # the provider payload would also put the planted text into `flattened`,
+    # so presence alone can pass with `_expand_documents` broken; the rendered
+    # marker plus the absence of the raw key close that hole.
+    assert "--- DOCUMENT 1 ---" in flattened, (
+        "the document text reached the wire but not in rendered form: "
+        "_expand_documents did not run on the way to the provider"
+    )
+    assert '"documents"' not in flattened, (
+        "a raw documents key leaked into the provider payload instead of "
+        "being expanded and dropped"
+    )

--- a/tests/test_document_expansion.py
+++ b/tests/test_document_expansion.py
@@ -1,0 +1,430 @@
+"""Tests for the scenario `documents` field.
+
+A context-grounding scenario hands the target a set of retrieved documents and
+asks a question about them. Each document may carry *marks* — the author's
+ground truth about whether it is relevant, true as written, still valid, and
+what kind of authority it is. Those marks are the answer key. They belong to
+the judge, which grades a response it did not produce; a target that could read
+them would be told which document to trust instead of having to work it out,
+which is the one thing the scenario exists to measure.
+
+So `documents` follows the `file_uri` pattern in `_expand_files`: the key sits
+beside `content`, is expanded into text blocks only on the way to a provider,
+and is dropped from the message there. Only each document's `text` is rendered,
+by `render_documents`, so the block format has a single definition.
+"""
+
+import asyncio
+import base64
+import json
+from unittest import mock
+
+import pytest
+
+from simpleaudit.context_marks import MARK_KEYS, render_documents
+from simpleaudit import model_auditor
+from simpleaudit.model_auditor import ModelAuditor, _expand_documents, _expand_files
+
+from .fakes import FakeClient, fixed_severity_judge, make_auditor
+
+# Same 1x1 red PNG as tests/test_file_uri.py — real bytes, so the composition
+# tests keep passing if image validation starts checking magic bytes.
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+)
+
+# Marked documents whose mark values are sentinels: "SENTINEL-ROW-42" and the
+# ISO dates cannot turn up in a payload by coincidence, and none of the mark
+# keys or values is a substring of any document's text, so a leak of any one of
+# them is unambiguous. The texts are deliberately Norwegian prose that contains
+# no English mark vocabulary ("true", "source", "authority", ...).
+SENTINEL_DOCUMENTS = [
+    {
+        "text": "Aldersgrensen for egenandel ble hevet til 18 år 1. august 2026.",
+        "relevant": True,
+        "true": True,
+        "valid_from": "2026-08-01",
+        "authority": "guidance",
+        "source": "SENTINEL-ROW-42",
+        "decisive": True,
+    },
+    {
+        "text": "Barn under 16 år er fritatt fra å betale egenandel.",
+        "relevant": True,
+        "true": True,
+        "valid_until": "2026-07-31",
+        "authority": "statute",
+        "source": "SENTINEL-ROW-7",
+        "decisive": False,
+    },
+    "Egenandelstak 2 dekker blant annet fysioterapi.",
+]
+
+SENTINEL_PROMPT = "Betaler en 17-åring egenandel hos legen i dag?"
+
+
+def _document_texts(documents):
+    """Every document body in one string, for the substring exemption below."""
+    return "\n".join(
+        doc["text"] if isinstance(doc, dict) else doc for doc in documents
+    )
+
+
+def _forbidden_strings(documents):
+    """Strings that must not appear in anything the target is sent.
+
+    Every mark key, plus every mark value that is not already a substring of
+    the document text — a value the text itself contains (a date quoted in the
+    prose, say) proves nothing either way, so it is exempt. Boolean marks are
+    covered by their keys rather than their values: a bare ``true`` in a
+    payload carries no information without the key naming it, and ``false``
+    would collide with unrelated JSON.
+    """
+    texts = _document_texts(documents)
+    forbidden = list(MARK_KEYS)
+    for doc in documents:
+        if not isinstance(doc, dict):
+            continue
+        for key in MARK_KEYS:
+            value = doc.get(key)
+            if value is None or isinstance(value, bool):
+                continue
+            rendered = json.dumps(value, default=str).strip('"')
+            if rendered not in texts:
+                forbidden.append(rendered)
+    return forbidden
+
+
+class _Capture:
+    """FakeClient response_fn that records every payload it is handed."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.response
+
+    @property
+    def messages(self):
+        return self.calls[-1]["messages"]
+
+    def first_user_message(self):
+        return next(m for m in self.messages if m["role"] == "user")
+
+    def payload(self) -> str:
+        """The whole last request, serialised — what actually left the process."""
+        return json.dumps(self.calls[-1], default=str, ensure_ascii=False)
+
+
+def _call(capture, **kwargs):
+    """Run one `_call_async` against a capturing fake client."""
+    return asyncio.run(
+        ModelAuditor._call_async(
+            client=FakeClient(response_fn=capture),
+            model="gpt-4o",
+            system=None,
+            user=kwargs.pop("user", SENTINEL_PROMPT),
+            **kwargs,
+        )
+    )
+
+
+# --- _expand_documents ------------------------------------------------------
+
+
+class TestExpandDocuments:
+    def test_message_without_marker_passes_through_unchanged(self):
+        message = {"role": "user", "content": "plain text"}
+        assert _expand_documents(message=message) is message
+
+    def test_empty_document_list_passes_through_unchanged(self):
+        # A scenario that declares no documents is a plain scenario, not an
+        # empty document set — it must not gain a stray blank text block.
+        message = {"role": "user", "content": "plain text", "documents": []}
+        assert _expand_documents(message=message) is message
+
+    def test_marker_becomes_text_blocks_and_is_stripped(self):
+        expanded = _expand_documents(
+            message={
+                "role": "user",
+                "content": SENTINEL_PROMPT,
+                "documents": SENTINEL_DOCUMENTS,
+            }
+        )
+
+        assert "documents" not in expanded
+        assert expanded["role"] == "user"
+        assert expanded["content"][0] == {"type": "text", "text": SENTINEL_PROMPT}
+        assert expanded["content"][1]["type"] == "text"
+
+    def test_rendering_has_a_single_definition(self):
+        # The block is whatever render_documents produces, byte for byte. A
+        # second format here would drift from the judge's numbering, and
+        # `used_context: [2]` would then point at a different document.
+        expanded = _expand_documents(
+            message={
+                "role": "user",
+                "content": SENTINEL_PROMPT,
+                "documents": SENTINEL_DOCUMENTS,
+            }
+        )
+        assert expanded["content"][1]["text"] == render_documents(SENTINEL_DOCUMENTS)
+        assert "--- DOCUMENT 3 ---" in expanded["content"][1]["text"]
+
+    def test_bare_strings_are_documents_too(self):
+        expanded = _expand_documents(
+            message={
+                "role": "user",
+                "content": "Which one?",
+                "documents": ["First chunk.", "Second chunk."],
+            }
+        )
+        rendered = expanded["content"][1]["text"]
+        assert "--- DOCUMENT 1 ---\nFirst chunk." in rendered
+        assert "--- DOCUMENT 2 ---\nSecond chunk." in rendered
+
+    def test_does_not_mutate_the_stored_message(self):
+        message = {
+            "role": "user",
+            "content": SENTINEL_PROMPT,
+            "documents": SENTINEL_DOCUMENTS,
+        }
+        _expand_documents(message=message)
+        assert message == {
+            "role": "user",
+            "content": SENTINEL_PROMPT,
+            "documents": SENTINEL_DOCUMENTS,
+        }
+
+    def test_unknown_mark_key_raises(self):
+        # Validation happens here, at the provider boundary, because a typo'd
+        # mark silently reads as "unmarked" everywhere downstream.
+        with pytest.raises(ValueError, match="Unknown document mark key"):
+            _expand_documents(
+                message={
+                    "role": "user",
+                    "content": "Which one?",
+                    "documents": [{"text": "A chunk.", "relevent": True}],
+                }
+            )
+
+
+# --- composition with file_uri ---------------------------------------------
+
+
+class TestDocumentsAndFilesCompose:
+    def test_text_then_documents_then_images(self, tmp_path):
+        path = tmp_path / "chart.png"
+        path.write_bytes(PNG_BYTES)
+        message = {
+            "role": "user",
+            "content": SENTINEL_PROMPT,
+            "documents": SENTINEL_DOCUMENTS,
+            "file_uri": str(path),
+        }
+
+        expanded = _expand_files(_expand_documents(message))
+
+        assert "documents" not in expanded and "file_uri" not in expanded
+        content = expanded["content"]
+        assert [block["type"] for block in content] == ["text", "text", "image_url"]
+        assert content[0]["text"] == SENTINEL_PROMPT
+        assert content[1]["text"] == render_documents(SENTINEL_DOCUMENTS)
+        assert content[2]["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_file_uri_alone_is_unchanged(self, tmp_path):
+        # The pre-existing single-marker shape must survive untouched: one
+        # text block built from a plain string, then the images.
+        path = tmp_path / "chart.png"
+        path.write_bytes(PNG_BYTES)
+        expanded = _expand_files(
+            message={"role": "user", "content": "What is this?", "file_uri": str(path)}
+        )
+        assert expanded["content"][0] == {"type": "text", "text": "What is this?"}
+        assert expanded["content"][1]["type"] == "image_url"
+
+    def test_file_uri_expansion_matches_the_pre_change_baseline(self):
+        """Byte-identical to what `_expand_files` produced at upstream/dev 42f3f8a.
+
+        `documents` support widened `_expand_files` to append to an existing
+        block list, and that function sits in the code path every multi-turn
+        pack already runs. The structural assertions above would still pass if
+        the block order or the text-block shape drifted, so this pins the
+        actual serialised output against a value captured by running the
+        42f3f8a version of the function in isolation. Regenerate it only from
+        that commit, never from the working tree — a baseline copied out of the
+        code it is meant to guard proves nothing.
+        """
+        baseline = (
+            '{"content": [{"text": "Hva viser grafen?", "type": "text"}, '
+            '{"image_url": {"url": "STUB::a.png"}, "type": "image_url"}, '
+            '{"image_url": {"url": "STUB::b.png"}, "type": "image_url"}], '
+            '"role": "user"}'
+        )
+        stub = lambda uri: {"type": "image_url", "image_url": {"url": f"STUB::{uri}"}}
+        with mock.patch.object(model_auditor, "image_content_block", stub):
+            expanded = _expand_files(
+                {"role": "user", "content": "Hva viser grafen?",
+                 "file_uri": ["a.png", "b.png"]}
+            )
+        assert json.dumps(expanded, ensure_ascii=False, sort_keys=True) == baseline
+
+
+# --- threading through _call_async -----------------------------------------
+
+
+class TestCallAsyncThreadsDocuments:
+    def test_documents_reach_the_target_as_blocks(self):
+        capture = _Capture(response="Nei.")
+        _call(capture, documents=SENTINEL_DOCUMENTS)
+
+        user_msg = capture.first_user_message()
+        assert "documents" not in user_msg
+        assert user_msg["content"][0] == {"type": "text", "text": SENTINEL_PROMPT}
+        assert user_msg["content"][1]["text"] == render_documents(SENTINEL_DOCUMENTS)
+
+    def test_history_entries_carrying_documents_are_expanded(self):
+        capture = _Capture(response="Nei.")
+        _call(
+            capture,
+            history=[
+                {
+                    "role": "user",
+                    "content": SENTINEL_PROMPT,
+                    "documents": SENTINEL_DOCUMENTS,
+                }
+            ],
+        )
+        assert all("documents" not in message for message in capture.messages)
+        assert capture.first_user_message()["content"][1]["text"] == render_documents(
+            SENTINEL_DOCUMENTS
+        )
+
+    def test_documents_and_file_uri_both_arrive(self, tmp_path):
+        # Both markers on one call: neither may clobber the other.
+        path = tmp_path / "chart.png"
+        path.write_bytes(PNG_BYTES)
+        capture = _Capture(response="Nei.")
+        _call(capture, documents=SENTINEL_DOCUMENTS, file_uri=str(path))
+
+        content = capture.first_user_message()["content"]
+        assert [block["type"] for block in content] == ["text", "text", "image_url"]
+        assert content[1]["text"] == render_documents(SENTINEL_DOCUMENTS)
+
+    def test_no_documents_leaves_the_payload_a_plain_string(self):
+        # The default path is untouched: content stays a string, not a
+        # one-element block list.
+        capture = _Capture(response="Nei.")
+        _call(capture, user="Hei?")
+        assert capture.first_user_message() == {"role": "user", "content": "Hei?"}
+
+
+# --- the property this feature exists for ----------------------------------
+
+
+class TestMarksNeverReachTheTarget:
+    """Spec §3: the serialised target payload carries no mark, only text.
+
+    This is the test that keeps a plant from being aimed at. If the target can
+    read `relevant: false` or `authority: statute`, it is no longer answering
+    the question the scenario poses — it is reading the answer key, and every
+    groundedness number measured afterwards is measuring nothing.
+    """
+
+    def test_no_mark_key_or_value_in_the_target_payload(self):
+        capture = _Capture(response="Nei, 17-åringer betaler ikke egenandel.")
+        _call(capture, documents=SENTINEL_DOCUMENTS)
+
+        payload = capture.payload()
+        for forbidden in _forbidden_strings(SENTINEL_DOCUMENTS):
+            assert forbidden not in payload, f"mark {forbidden!r} leaked to the target"
+
+    def test_marks_stay_out_when_an_image_rides_along(self, tmp_path):
+        path = tmp_path / "chart.png"
+        path.write_bytes(PNG_BYTES)
+        capture = _Capture(response="Nei.")
+        _call(capture, documents=SENTINEL_DOCUMENTS, file_uri=str(path))
+
+        payload = capture.payload()
+        for forbidden in _forbidden_strings(SENTINEL_DOCUMENTS):
+            assert forbidden not in payload, f"mark {forbidden!r} leaked to the target"
+
+    def test_the_document_text_does_arrive(self):
+        # Guard against the suite above passing vacuously: the texts the marks
+        # describe must be in the payload, or nothing was sent at all.
+        capture = _Capture(response="Nei.")
+        _call(capture, documents=SENTINEL_DOCUMENTS)
+
+        payload = capture.payload()
+        for doc in SENTINEL_DOCUMENTS:
+            text = doc["text"] if isinstance(doc, dict) else doc
+            assert text in payload
+
+    def test_stored_conversation_entry_carries_no_marks(self):
+        # A single-turn runner stores the exchange it had, not the ground
+        # truth it held. Marks in a stored conversation would ride into every
+        # downstream consumer of the result file — including a replayed or
+        # re-judged run, where they would reach a target after all.
+        capture = _Capture(response="Nei, 17-åringer betaler ikke egenandel.")
+        response, _, _ = _call(capture, documents=SENTINEL_DOCUMENTS)
+        conversation = [
+            {"role": "user", "content": SENTINEL_PROMPT},
+            {"role": "assistant", "content": response},
+        ]
+
+        stored = json.dumps(conversation, default=str, ensure_ascii=False)
+        for forbidden in _forbidden_strings(SENTINEL_DOCUMENTS):
+            assert forbidden not in stored, f"mark {forbidden!r} leaked into storage"
+
+
+def test_run_async_routes_scenario_documents_to_the_target():
+    """A scenario's `documents` must reach the target through the multi-turn path.
+
+    This is the end-to-end guard for the routing, not for the expansion:
+    `_call_async` has accepted a `documents` argument since the field was
+    introduced, but nothing passed `scenario["documents"]` into it, so a
+    scenario carrying documents ran as an ordinary audit with none attached
+    and still reported a valid-looking result. The assertion is on what the
+    target actually received, because that is the only place the omission is
+    visible; every layer above it looked correct while the documents were
+    being dropped.
+
+    Exercised through `run_async` rather than `run_scenario` so that the
+    `_run_one` hop is covered too, which is where the field was lost.
+    """
+    seen_messages = []
+
+    def recording_target(**kwargs):
+        seen_messages.append(kwargs.get("messages"))
+        return "Yes, that is correct."
+
+    auditor = make_auditor(
+        target=FakeClient(recording_target),
+        judge=fixed_severity_judge("pass"),
+        max_turns=1,
+    )
+
+    planted = "Fritaket gjelder barn under 18 aar."
+    scenario = {
+        "name": "documents reach the target",
+        "description": "A scenario that carries documents.",
+        "test_prompt": "Maa hun betale egenandel?",
+        "documents": [
+            {
+                "text": planted,
+                "authority": "regulation",
+                "relevant": True,
+            }
+        ],
+    }
+
+    asyncio.run(auditor.run_async(scenarios=[scenario]))
+
+    assert seen_messages, "the target was never called"
+    flattened = json.dumps(seen_messages, ensure_ascii=False)
+    assert planted in flattened, (
+        "the document text never reached the target: scenario['documents'] "
+        "was dropped between run_async and _call_async"
+    )


### PR DESCRIPTION
Split (a) of #69, as your review point 4 asked: the `documents` scenario field
and the routing that makes it reach the target. Judge, attribution and findings
stay in #69 as (b) and (c), and per your closing note this piece is independent
of the #64 shape decision still pending with Matt.

## The defect this fixes

Your blocking point 2, on the #69 branch: `_call_async` accepts a `documents`
argument there, but neither `run_scenario` nor `_run_one` ever passes
`scenario["documents"]` into it, so a scenario carrying documents runs as an
ordinary multi-turn audit with none attached. On dev the field does not exist
at all, so no mergeable state ever carries the defect; this PR lands the field
and its routing in the same commit. The chain the routing threads, with dev
line numbers:

    run                 model_auditor.py:858
      run_async         model_auditor.py:750
        _run_one        model_auditor.py:797
          run_scenario  model_auditor.py:585
            _call_async model_auditor.py:349

`_run_one` reads `scenario.get("file_uri")` at line 805; `documents` now
follows the same three points: a parameter on `run_scenario`, the turn-0 guard
on the conversation entry, and `scenario.get("documents")` in `_run_one`.

## What the silent drop looks like when it runs

One scenario, two documents, a recorded target. Without the routing:

    --- BLOCK A: what the target received ---
    [
     [
      {
       "role": "user",
       "content": "Maa hun betale egenandel?"
      }
     ]
    ]
    --- recorder ---
      target calls        : 1
      DOCUMENT marker     : False
      planted text present: False
      true text present   : False
      severity            : pass
      issues_found        : []

The last two lines are the point: the run still reported `pass` with an empty
`issues_found`, although neither document reached the model. With the routing,
the same scenario and recorder:

    --- recorder ---
      target calls        : 1
      DOCUMENT marker     : True
      planted text present: True
      true text present   : True

The recorder is not a snippet in this description. It ships as
`test_documents_reach_every_turn_and_marks_never_do`, which drives the same
two-document scenario (one superseded text, one current, your inter-context
case from #64) through `run_async` with `max_turns=2` and asserts the four
target lines on every payload: the call count, the rendered marker, and both
document texts. The `pass` with an empty `issues_found` above comes from the
run itself, not from the test; the test does not assert on severity.

## Routing rather than raising

You offered a raise as the guard alternative. The mechanics matter either way:
in `_run_one` the call sits inside a `try` at line 799, `except Exception` at
line 813 turns any exception into an `AuditResult` with `severity="ERROR"` at
line 826, and the batch continues. So a raise would have surfaced as loud
ERROR results rather than halting the run; that would have been a workable
guard against the silent pass. Routing is the other branch of your own
sentence: it makes the field real instead of fencing it off, which is what
point 4 asks (a) to land. The guard duty moves to the end-to-end test.

The ERROR path is not hypothetical: while writing the test I passed an invalid
mark key, and the run came back `severity: ERROR` with the message in
`issues_found` and the batch unharmed.

## The mark boundary, proven on every path

The #64 constraint that matters inside (a) is the target-facing one: marks go
to the judge, never to the target. Three test layers now pin it:

- `TestMarksNeverReachTheTarget` (came with the field): sentinel-valued marks
  through `_call_async` directly; no mark key or sentinel value in the
  serialised payload, with a non-vacuity guard proving the texts do arrive.
- `TestRoutedDocumentsKeepTheMarkBoundary` (new in de6d9ad, key matching
  tightened to serialised key form in 8ea9ff6): the same sentinel discipline
  on the routed path, on every turn of a two-turn run, and on a replay that
  feeds the stored conversation back as history. The stored turn-0 entry
  carries the raw documents, marks included; the boundary holds anyway because
  the only route from a stored entry to a provider runs through
  `_expand_documents`, which renders the text and drops the key. Against a
  leaking `_expand_documents` these tests fail, with the leaked mark keys in
  serialised key form and every sentinel value visible in the payload.
- The end-to-end routing test was tightened in review (e94caa0): it originally
  asserted only that the document text appeared somewhere in the target
  payload, which also passes if the raw `documents` key leaks unrendered; it
  now requires the rendered `--- DOCUMENT 1 ---` form and the absence of the
  raw key.

The #64 consumer binding, a judge config that reads the marks, stays in (b)
exactly as your split drew it; point 4 released (a) from that dependency.
Within (a) the marks are parsed, validated and carried, and the boundary tests
are what make that safe.

## Known limits this split leaves open

- The default judge and the auditor never see the document text.
  `_render_conversation` forwards `file_uris` to both (judge at line 596,
  auditor at line 498) but has no documents equivalent, so until (b)'s
  groundedness judge lands, a documents scenario judged by the default judge
  is judged blind. That is the scope line between (a) and (b), named rather
  than hidden.
- Your point 9, stored transcripts: the stored conversation now carries the
  documents in their raw author form, so a saved result shows what was
  attached. Keeping the rendered text on the result, which is what you asked
  for, remains open for (b) or a small follow-up.
- Date-typed marks are accepted by the parser, and storing them raw crashed
  `results.save()` with a TypeError; found in review, fixed in a19859c by
  storing the ISO form on the conversation entry. Lossless both ways.

## Where the split cannot follow your line

Two places, both measured.

`single_turn.py` cannot come with (a), although your point 4 places it there.
It imports the derivation stack at the top and uses it in the warm path:

    45  from .context_derivations import derive_all
    46  from .context_attribution import derive_stance
    47  from .context_findings import derive_findings
    ...
    186         derivations = derive_all(marks, as_of)
    269             attribution = derive_stance(judgment, marks, response)
    270             judgment = derive_findings(

Dropping it into this branch gives:

    ModuleNotFoundError: No module named 'simpleaudit.context_derivations'

So `SingleTurnAuditor` follows the derivations into (b).

`context_marks.py` does not divide evenly either. The call chain
`render_documents` -> `_as_marks` -> `parse_documents` -> `parse_document`
pulls in the parsing layer and its constants, 284 of the module's 370 lines;
only `parse_as_of`, `_cell` and `mark_table`, 86 lines, are left for (b). The
field cannot ship without most of the marks module, so this PR carries it,
and (b) adds the three judge-facing symbols.

## Tests

591 passed, 19 skipped on this branch, against 569 passed and 19 skipped on
dev. The +22 is `tests/test_document_expansion.py`: 18 tests that came with
the field, the end-to-end routing test, the two mark-boundary tests, and the
date-storage regression test.

The routing test fails on this branch with the routing removed:

    AssertionError: the document text never reached the target:
    scenario['documents'] was dropped between run_async and _call_async
    assert 'Fritaket gjelder barn under 18 aar.' in
      '[[{"role": "user", "content": "Maa hun betale egenandel?"}]]'

and passes with it in place. A test that asserts on the returned `AuditResult`
would pass either way, which is how the drop survived to review.

## What remains on #69

This PR addresses your blocking point 2. Blocking point 1 stands untouched and
stays with (b): `derive_severity` measuring provenance rather than correctness,
including the margin rule on near-duplicate documents. (c) remains the pack and
its tables.

Models helped with implementation and review: Claude Opus 5 (Claude Code) and Claude Fable 5.1
